### PR TITLE
Unify all date handling at the +page.svelte level

### DIFF
--- a/src/components/navigation/header.svelte
+++ b/src/components/navigation/header.svelte
@@ -1,41 +1,7 @@
 <script>
 	import { formatDate, formatTime } from '$lib/formatters.js';
-	import { browser } from '$app/environment';
-	import { onMount, onDestroy } from 'svelte';
 
-	let { title, imageUrl } = $props();
-
-	let currentTime = new Date();
-	let currentDate = new Date();
-	let countdown = $state(30); // Initialize countdown to 30 seconds
-
-	let intervalTimer, refreshTimer;
-
-	function startClock() {
-		intervalTimer = setInterval(() => {
-			currentTime = new Date();
-			currentDate = new Date();
-			countdown = countdown > 0 ? countdown - 1 : 30; // Reset countdown after refresh
-		}, 1000);
-	}
-
-	function startAutoRefresh() {
-		refreshTimer = setInterval(() => {
-			window.location.reload();
-		}, 30000); // Refresh every 30 seconds
-	}
-
-	onMount(() => {
-		if (browser) {
-			startClock();
-			startAutoRefresh();
-		}
-	});
-
-	onDestroy(() => {
-		clearInterval(intervalTimer);
-		clearInterval(refreshTimer);
-	});
+	let { countdown, currentDate, imageUrl, title } = $props();
 </script>
 
 <div class="flex gap-x-4 p-2">
@@ -51,7 +17,7 @@
 	</div>
 	<div class="flex-1 text-right">
 		<div class="text-sm">{formatDate(currentDate)}</div>
-		<div class="text-3xl font-bold">{formatTime(currentTime)}</div>
+		<div class="text-3xl font-bold">{formatTime(currentDate)}</div>
 		<div class="text-sm text-gray-500">Refreshing in {countdown}s</div>
 	</div>
 </div>


### PR DESCRIPTION
Instead of spreading our countdown and refresh responsibilities around, create a unified source of truth about the current time and the countdown.