### PR TITLE
Updated UI

### DIFF
--- a/src/components/navigation/footer.svelte
+++ b/src/components/navigation/footer.svelte
@@ -1,9 +1,7 @@
 <script>
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
-
-	let stopName = $state('Loading stop information...');
-	let stopCode = $state('');
+	import { stopInfo } from '$lib/store';
 
 	async function fetchStopInfo() {
 		try {
@@ -11,14 +9,13 @@
 			if (!response.ok) throw new Error('Failed to fetch stop information');
 			const data = await response.json();
 			if (data) {
-				stopName = data.name;
-				stopCode = data.code;
+				stopInfo.set({name: data.name, code: data.code});
 				return true;
 			}
 			return false;
 		} catch (error) {
 			console.error('Error fetching stop information:', error);
-			stopName = 'Unknown Stop';
+			stopInfo.set({name: "Unknown Stop", code: ""});
 			return false;
 		}
 	}
@@ -34,9 +31,6 @@
 	<div class="flex items-center justify-between">
 		<div class="flex items-center">
 			<span class="ml-2 text-sm">Waystation by Open Transit Software Foundation</span>
-		</div>
-		<div class="text-sm">
-			Stop No. {stopCode} - {stopName}
 		</div>
 	</div>
 </div>

--- a/src/components/navigation/footer.test.js
+++ b/src/components/navigation/footer.test.js
@@ -30,5 +30,4 @@ test('renders successfully', async () => {
 	await vi.runAllTimersAsync();
 
 	expect(div.innerHTML).toContain('Waystation by Open Transit Software Foundation');
-	expect(div.innerHTML).toContain('Stop Test Example');
 });

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,0 +1,6 @@
+import {writable} from "svelte/store";
+
+export const stopInfo = writable({
+	name: "Loading stop information...",
+	code: ""
+});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { PUBLIC_OBA_LOGO_URL, PUBLIC_OBA_REGION_NAME } from '$env/static/public';
 	import { formatTime2 } from '$lib/formatters';
+	import {stopInfo} from "$lib/store";
 
 	import Header from '$components/navigation/header.svelte';
 	import Footer from '$components/navigation/footer.svelte';
@@ -42,7 +43,7 @@
 				minutes: null,
 				displayTime: formatTime2(predictedTime)
 			};
-		} else if (predictedDiff <= 20) {
+		} else if (predictedDiff <= 10) {
 			return {
 				status: 'Arriving',
 				text: 'Arriving in',
@@ -105,6 +106,10 @@
 		currentDate={now}
 		{countdown}
 	/>
+
+	<div class="flex justify-center bg-blue-400 font-bold text-xl py-2 px-2">
+		Stop No. {$stopInfo.code} - {$stopInfo.name}
+	</div>
 
 	<div class="flex-1 bg-gray-200 text-black">
 		{#if loading}


### PR DESCRIPTION
**Changes:**
- Moved stop information from the footer to the center of the page for better visibility
- Redesigned stop info as a flexbox with a blue background and bold font, following global transit display conventions for emphasis
- Updated getArrivalStatus() to display "Arriving" at ≤10 minutes instead of 20 minutes
- Replaced local variables (stopName and stopCode) in footer.svelte with Svelte stores (stores.js) for better state management

**Before:**
![image](https://github.com/user-attachments/assets/ab38560c-87ab-43a6-861c-80f2670a93ad)

**After:**
![image](https://github.com/user-attachments/assets/56d695e5-9047-4946-9147-e1bd0f09a1c8)
