### PR TITLE
Refactored departure display logic & internal formatting structure

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,23 +3,25 @@
 @plugin '@tailwindcss/typography';
 
 body {
-	position: relative;
-	background-color: gray;
-	margin: 0;
+	@apply relative m-0 bg-gray-500;
 }
 
 body::before {
+	inset: 0;
 	content: '';
 	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
 	background-image: url('/background.png');
-	background-size: cover;
-	background-repeat: no-repeat;
-	background-attachment: fixed;
-	background-position: center;
-	opacity: 0.85;
-	z-index: -1;
+	@apply -z-10 bg-cover bg-fixed bg-center bg-no-repeat opacity-85;
+}
+
+@theme {
+	--color-brand-darkblue: oklch(0.3936 0.0901 239.99);
+	--color-brand-darkerblue: oklch(0.2583 0.0561 236.7);
+	--color-brand-gray: oklch(0.6434 0 0);
+	--color-brand-lightgray: oklch(0.2583 0.0561 236.7 / 40%);
+	--color-brand-red: oklch(0.6117 0.2216 29.64);
+	--color-brand-blue: oklch(0.6145 0.174877 250.2013);
+	--shadow-red: 0 0 10px 10px rgba(235, 50, 35, 0.03);
+	--shadow-blue: 0 0 10px 10px rgba(0, 149, 255, 0.07);
+	--shadow-gray: 0 0 10px 10px rgba(0, 0, 0, 0.08);
 }

--- a/src/app.css
+++ b/src/app.css
@@ -24,4 +24,5 @@ body::before {
 	--shadow-red: 0 0 10px 10px rgba(235, 50, 35, 0.03);
 	--shadow-blue: 0 0 10px 10px rgba(0, 149, 255, 0.07);
 	--shadow-gray: 0 0 10px 10px rgba(0, 0, 0, 0.08);
+	--color-oba-green: oklch(0.632 0.1728 138.8);
 }

--- a/src/components/alerts/alerts.svelte
+++ b/src/components/alerts/alerts.svelte
@@ -10,17 +10,15 @@
 
 	const dateStart = formatTimestamp(activeWindow.from ?? '');
 	const dateEnd = formatTimestamp(activeWindow.to ?? '');
-
-	const gray_bg = 'bg-[rgba(0,39,59,0.05)] font-bold px-5.5 py-1.5 corner rounded-[24px]';
 </script>
 
 {#if title}
 	<div class="m-5">
 		<div
-			class={`${gray_bg} bg-white py-5.5 text-[#003956]`}
+			class="text-brand-darkerblue corner rounded-[24px] bg-white px-5.5 py-8 font-bold"
 			style="box-shadow: 0 0 20px 1px rgba(0,0,0,0.15);"
 		>
-			<div class="flex items-center justify-center text-4xl font-bold text-[#FF5E51]">
+			<div class="text-brand-red flex items-center justify-center text-4xl font-bold">
 				Your attention required!
 			</div>
 
@@ -29,11 +27,12 @@
 			</div>
 
 			{#if validateTimestamp(dateStart) && validateTimestamp(dateEnd)}
-				<div class={`${gray_bg} flex items-center justify-center text-3xl`}>
-					<span class="whitespace-nowrap"
-						><span class="text-[#4BA12C]">{dateStart}</span> ➔
-						<span class="text-[#4BA12C]">{dateEnd}</span></span
-					>
+				<div class="flex items-center justify-center text-3xl">
+					<span class="whitespace-nowrap">
+						<span class="text-oba-green">{dateStart}</span>
+						➔
+						<span class="text-oba-green">{dateEnd}</span>
+					</span>
 				</div>
 			{/if}
 		</div>

--- a/src/components/alerts/alerts.test.js
+++ b/src/components/alerts/alerts.test.js
@@ -15,7 +15,6 @@ describe('Alerts component', () => {
 				situations: [
 					{
 						summary: { value: 'Test Alert Title' },
-						// description: { value: 'Test Alert Description' },
 						activeWindows: [
 							{
 								from: 1718948400000,
@@ -30,8 +29,6 @@ describe('Alerts component', () => {
 		});
 
 		expect(container.textContent).toContain('Test Alert Title');
-		// expect(container.textContent).toContain('Test Alert Description');
-		// expect(container.textContent).toContain('Unknown');
 	});
 
 	test('does not render when title is missing, even if a description exists', () => {

--- a/src/components/controller/controller.svelte
+++ b/src/components/controller/controller.svelte
@@ -88,7 +88,7 @@
 </script>
 
 <div class="flex flex-1 overflow-hidden">
-	<div class="flex flex-1 flex-col overflow-y-auto text-[#004B71]">
+	<div class="text-brand-darkblue flex flex-1 flex-col overflow-y-auto">
 		{#if loading}
 			<div class="flex h-32 items-center justify-center">
 				<p class="text-xl">Loading departures...</p>

--- a/src/components/controller/controller.svelte
+++ b/src/components/controller/controller.svelte
@@ -91,7 +91,7 @@
 	<div class="flex flex-1 flex-col overflow-y-auto text-[#004B71]">
 		{#if loading}
 			<div class="flex h-32 items-center justify-center">
-				<p class="text-xl text-gray-600">Loading departures...</p>
+				<p class="text-xl">Loading departures...</p>
 			</div>
 		{:else if allDepartures.length > 0}
 			<div class="flex flex-col">
@@ -103,7 +103,7 @@
 			</div>
 		{:else}
 			<div class="flex h-32 items-center justify-center">
-				<p class="text-xl text-gray-600">No departures available</p>
+				<p class="text-xl">No departures available</p>
 			</div>
 		{/if}
 	</div>

--- a/src/components/departures/departure.svelte
+++ b/src/components/departures/departure.svelte
@@ -22,11 +22,11 @@
 </script>
 
 <div
-	class={`flex items-center rounded-[32px] border-r-7 border-l-7 ${departure.borderColor} m-4 bg-[rgba(255,255,255,0.85)] p-5`}
-	style={`box-shadow: 0 0 10px 10px ${departure.shadowColor}`}
+	class={`flex items-center rounded-[32px] border-x-7 ${departure.borderColor} m-4 bg-white/75 p-5`}
+	style={`box-shadow: ${departure.shadowColor}`}
 >
 	<div
-		class="mr-5 flex min-w-42 items-center justify-center rounded-[20px] bg-[#00273B] px-7 py-6 text-4xl font-black whitespace-nowrap text-white"
+		class="bg-brand-darkerblue mr-5 flex min-w-42 items-center justify-center rounded-[20px] px-7 py-6 text-4xl font-black whitespace-nowrap text-white"
 	>
 		{dep.routeShortName}
 	</div>

--- a/src/components/departures/departure.svelte
+++ b/src/components/departures/departure.svelte
@@ -1,49 +1,29 @@
 <script>
-	import { formatArrivalStatus, formatRouteStatus } from '$lib/formatters';
+	import {
+		formatArrivalStatus,
+		formatRouteStatus,
+		formatBorderColor,
+		formatShadowColor,
+		formatTextColor
+	} from '$lib/formatters';
 	import { ArrowDownRight, ArrowUpLeft, ChevronRight } from '@lucide/svelte';
 
 	const { dep } = $props();
 
-	const status = formatArrivalStatus(dep.predictedDepartureTime, dep.scheduledDepartureTime);
+	const depStatus = formatArrivalStatus(dep.predictedDepartureTime, dep.scheduledDepartureTime);
 	const routeStatus = formatRouteStatus(dep.predictedDepartureTime, dep.scheduledDepartureTime);
 
-	const COLOR_CLASSES = {
-		green: 'text-green-500',
-		red: 'text-red-500',
-		blue: 'text-[#0087E8]',
-		gray: 'text-[#8D8D8D]'
+	const departure = {
+		...depStatus,
+		...formatBorderColor(depStatus.status, routeStatus.status),
+		...formatShadowColor(depStatus.status, routeStatus.status),
+		...formatTextColor(depStatus.status, routeStatus.status)
 	};
-
-	const BORDER_COLORS = {
-		green: 'border-[#00BD2F]',
-		red: 'border-[#EB3223]',
-		blue: 'border-[#0087E8]',
-		default: 'border-[#00273B66]'
-	};
-
-	const SHADOW_COLORS = {
-		green: 'rgba(0,189,47,0.1)',
-		red: 'rgba(235,50,35,0.03)',
-		blue: 'rgba(0,149,255,0.07)',
-		default: 'rgba(0,0,0,0.08)'
-	};
-
-	const colorClass = COLOR_CLASSES[routeStatus.color] ?? COLOR_CLASSES.gray;
-
-	const isDeparting = status.status === 'Departing';
-
-	const borderColor = isDeparting
-		? BORDER_COLORS.default
-		: (BORDER_COLORS[routeStatus.color] ?? BORDER_COLORS.default);
-
-	const shadowColor = isDeparting
-		? SHADOW_COLORS.default
-		: (SHADOW_COLORS[routeStatus.color] ?? SHADOW_COLORS.default);
 </script>
 
 <div
-	class={`m-4 flex items-center rounded-[32px] border-r-7 border-l-7 ${borderColor} bg-[rgba(255,255,255,0.85)] p-5`}
-	style={`box-shadow: 0 0 10px 10px ${shadowColor}`}
+	class={`flex items-center rounded-[32px] border-r-7 border-l-7 ${departure.borderColor} m-4 bg-[rgba(255,255,255,0.85)] p-5`}
+	style={`box-shadow: 0 0 10px 10px ${departure.shadowColor}`}
 >
 	<div
 		class="mr-5 flex min-w-42 items-center justify-center rounded-[20px] bg-[#00273B] px-7 py-6 text-4xl font-black whitespace-nowrap text-white"
@@ -62,33 +42,31 @@
 	</div>
 
 	<div class="ml-3 flex items-end gap-1">
-		{#if status.status === 'Departing'}
+		{#if departure.status === 'Departing'}
 			<div class="flex items-center">
 				<ArrowUpLeft strokeWidth={2.3} size={42} />
-				<span class="ml-3 text-4xl font-bold whitespace-nowrap">
-					{status.text}
-				</span>
+				<span class="ml-3 text-4xl font-bold whitespace-nowrap"> Departing now </span>
 			</div>
 		{:else}
 			<div class="flex flex-col items-end">
-				{#if status.status === 'Scheduled'}
+				{#if departure.status === 'Scheduled'}
 					<span class="text-6xl font-bold whitespace-nowrap">
-						{status.displayTime}
+						{departure.scheduledTime}
 					</span>
-				{:else if status.minutes !== null}
+				{:else if departure.status === 'Arriving'}
 					<div class="flex items-center gap-3 font-semibold whitespace-nowrap">
-						<ArrowDownRight class={colorClass} strokeWidth={2.3} size={42} />
-						<span class="text-4xl whitespace-nowrap">{status.text}</span>
-						<span class={`${COLOR_CLASSES[routeStatus.color]} text-5xl font-bold`}>
-							{status.minutes}
+						<ArrowDownRight class={departure.textColor} strokeWidth={2.3} size={42} />
+						<span class="text-4xl whitespace-nowrap">Arriving in</span>
+						<span class={`${departure.textColor} text-5xl font-bold`}>
+							{departure.eta}
 						</span>
 						<span class="text-4xl">min</span>
 					</div>
 				{/if}
 
-				{#if routeStatus.status}
-					<span class={`${COLOR_CLASSES[routeStatus.color]} text-3xl font-bold`}>
-						{routeStatus.status}
+				{#if routeStatus.tag}
+					<span class={`${departure.textColor} text-3xl font-bold`}>
+						{routeStatus.tag}
 					</span>
 				{/if}
 			</div>

--- a/src/components/departures/departure.svelte
+++ b/src/components/departures/departure.svelte
@@ -61,36 +61,37 @@
 		</span>
 	</div>
 
-	<div class="ml-3 flex items-center gap-1">
+	<div class="ml-3 flex items-end gap-1">
 		{#if status.status === 'Departing'}
 			<div class="flex items-center">
 				<ArrowUpLeft strokeWidth={2.3} size={42} />
-				<span class="ml-3 text-4xl font-bold whitespace-nowrap">{status.text}</span>
-			</div>
-		{:else if status.minutes !== null}
-			<div class="flex items-center gap-3 font-semibold whitespace-nowrap">
-				<ArrowDownRight class={colorClass} strokeWidth={2.3} size={42} />
-				<span class="text-4xl whitespace-nowrap">{status.text}</span>
-				<span class={`${COLOR_CLASSES[routeStatus.color]} text-5xl font-bold`}
-					>{status.minutes}</span
-				>
-				<span class="text-4xl">min</span>
-			</div>
-		{/if}
-
-		{#if status.status === 'Arriving' && (routeStatus.status || status.status === 'Scheduled')}
-			<ChevronRight size={36} class="text-gray-400" />
-		{/if}
-
-		<div class="flex flex-col items-end">
-			{#if status.status === 'Scheduled'}
-				<span class="text-6xl font-bold whitespace-nowrap">{status.displayTime}</span>
-			{/if}
-			{#if routeStatus.status && status.status !== 'Departing'}
-				<span class={`${COLOR_CLASSES[routeStatus.color]} text-3xl font-bold`}>
-					{routeStatus.status}
+				<span class="ml-3 text-4xl font-bold whitespace-nowrap">
+					{status.text}
 				</span>
-			{/if}
-		</div>
+			</div>
+		{:else}
+			<div class="flex flex-col items-end">
+				{#if status.status === 'Scheduled'}
+					<span class="text-6xl font-bold whitespace-nowrap">
+						{status.displayTime}
+					</span>
+				{:else if status.minutes !== null}
+					<div class="flex items-center gap-3 font-semibold whitespace-nowrap">
+						<ArrowDownRight class={colorClass} strokeWidth={2.3} size={42} />
+						<span class="text-4xl whitespace-nowrap">{status.text}</span>
+						<span class={`${COLOR_CLASSES[routeStatus.color]} text-5xl font-bold`}>
+							{status.minutes}
+						</span>
+						<span class="text-4xl">min</span>
+					</div>
+				{/if}
+
+				{#if routeStatus.status}
+					<span class={`${COLOR_CLASSES[routeStatus.color]} text-3xl font-bold`}>
+						{routeStatus.status}
+					</span>
+				{/if}
+			</div>
+		{/if}
 	</div>
 </div>

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -2,11 +2,11 @@
  * Format time for display
  * @param {Date} date
  */
-export function formatTime(date) {
+export function formatDateTime(date) {
 	return date.toLocaleTimeString('en-US', {
 		hour: 'numeric',
 		minute: '2-digit',
-		second: '2-digit', // Add this line to show seconds
+		second: '2-digit',
 		hour12: true
 	});
 }
@@ -14,62 +14,129 @@ export function formatTime(date) {
 // Get status for arrival or departure
 export function formatArrivalStatus(predictedTime, scheduledTime) {
 	const now = new Date();
+
 	const predicted = new Date(predictedTime);
 	const scheduled = new Date(scheduledTime);
 
 	const predictedDiff = Math.floor((predicted - now) / 60000);
 	const scheduledDiff = Math.floor((scheduled - now) / 60000);
 
+	// No predicted time, use scheduled time
 	if (predictedTime === 0) {
-		// No predicted time, use scheduled time
-		if (scheduledDiff <= 10) {
+		if (scheduledDiff < 10) {
 			return {
 				status: 'Arriving',
-				text: 'Arriving in',
-				color: 'text-blue-500',
-				minutes: scheduledDiff,
-				displayTime: formatTime2(scheduledTime)
+				eta: scheduledDiff,
+				scheduledTime: formatTime(scheduledTime)
 			};
 		} else {
 			return {
 				status: 'Scheduled',
-				text: '',
-				color: 'text-gray-500',
-				minutes: null,
-				displayTime: formatTime2(scheduledTime)
+				eta: null,
+				scheduledTime: formatTime(scheduledTime)
 			};
 		}
-	} else if (predictedDiff < -2) {
-		// If the bus left more than 2 minutes ago, it's already gone
+	}
+
+	// Bus left more than 2 minutes ago
+	if (predictedDiff < -2) {
 		return null;
-	} else if (predictedDiff <= 0) {
-		// If it's within 2 minutes of departure, show "Departing now"
+	}
+
+	if (predictedDiff <= 0) {
+		// Within 2 minutes
 		return {
 			status: 'Departing',
-			text: 'Departing now',
-			color: 'text-red-500',
-			minutes: null,
-			displayTime: formatTime2(predictedTime)
+			eta: null,
+			scheduledTime: formatTime(predictedTime)
 		};
 	} else if (predictedDiff < 10) {
 		// Within 10 minutes
 		return {
 			status: 'Arriving',
-			text: 'Arriving in',
-			color: 'text-blue-500',
-			minutes: predictedDiff,
-			displayTime: formatTime2(predictedTime)
+			eta: predictedDiff,
+			scheduledTime: formatTime(predictedTime)
 		};
 	} else {
-		// More than 10 minutes away -> show time only
+		// More than 10 minutes away
 		return {
 			status: 'Scheduled',
-			text: '',
-			color: 'text-gray-500',
-			minutes: null,
-			displayTime: formatTime2(predictedTime)
+			eta: null,
+			scheduledTime: formatTime(predictedTime)
 		};
 	}
+}
+
+export function formatBorderColor(defaultStatus, routeStatus) {
+	if (defaultStatus === 'Departing') {
+		return {
+			borderColor: 'border-[#8D8D8D]'
+		};
+	}
+
+	if (routeStatus === 'early') {
+		return {
+			borderColor: 'border-[#EB3223]'
+		};
+	}
+
+	if (routeStatus === 'late') {
+		return {
+			borderColor: 'border-[#0087E8]'
+		};
+	}
+
+	return {
+		borderColor: 'border-[#00273B66]'
+	};
+}
+
+export function formatShadowColor(defaultStatus, routeStatus) {
+	if (defaultStatus === 'Departing') {
+		return {
+			shadowColor: 'rgba(0,0,0,0.08)'
+		};
+	}
+
+	if (routeStatus === 'early') {
+		return {
+			shadowColor: 'rgba(235,50,35,0.03)'
+		};
+	}
+
+	if (routeStatus === 'late') {
+		return {
+			shadowColor: 'rgba(0,149,255,0.07)'
+		};
+	}
+
+	return {
+		shadowColor: 'rgba(0,0,0,0.08)'
+	};
+}
+
+export function formatTextColor(defaultStatus, routeStatus) {
+	if (defaultStatus === 'Departing') {
+		return {
+			textColor: ''
+		};
+	}
+
+	if (routeStatus === 'early') {
+		return {
+			textColor: 'text-[#EB3223]'
+		};
+	}
+
+	if (routeStatus === 'late') {
+		return {
+			textColor: 'text-[#0087E8]'
+		};
+	}
+
+	return {
+		textColor: 'text-[#8D8D8D]'
+	};
 }
 
 // Is the vehicle is early or late?
@@ -77,37 +144,40 @@ export function formatRouteStatus(predictedTime, scheduledTime) {
 	if (typeof predictedTime === 'undefined' || predictedTime === null || predictedTime === 0) {
 		return {
 			status: null,
-			color: 'gray'
+			tag: ''
 		};
 	}
 
 	const predicted = new Date(predictedTime);
 	const scheduled = new Date(scheduledTime);
+
 	const diff = Math.floor((predicted - scheduled) / 60000);
 
 	if (diff < -1) {
 		return {
-			status: `${Math.abs(diff)} min early`,
-			color: 'red'
-		};
-	} else if (diff > 1) {
-		return {
-			status: `${diff} min late`,
-			color: 'blue'
-		};
-	} else {
-		return {
-			status: null,
-			color: 'gray'
+			status: 'early',
+			tag: `${Math.abs(diff)} min early`
 		};
 	}
+
+	if (diff > 1) {
+		return {
+			status: 'late',
+			tag: `${diff} min late`
+		};
+	}
+
+	return {
+		status: 'on-time',
+		tag: null
+	};
 }
 
 /**
  * Format time for display
  * @param {Date} time
  */
-export function formatTime2(time) {
+export function formatTime(time) {
 	const date = new Date(time);
 	return date.toLocaleTimeString('en-US', {
 		hour: 'numeric',

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -11,7 +11,14 @@ export function formatDateTime(date) {
 	});
 }
 
-// Get status for arrival or departure
+/**
+ * Determines real-time arrival/departure status and timing
+ *
+ * @param {number} predictedTime - Predicted arrival timestamp (0 if unavailable)
+ * @param {number} scheduledTime - Scheduled arrival timestamp
+ *
+ * @returns {Object|null} Returns {status, eta, scheduledTime} or null if departed
+ */
 export function formatArrivalStatus(predictedTime, scheduledTime) {
 	const now = new Date();
 
@@ -67,79 +74,14 @@ export function formatArrivalStatus(predictedTime, scheduledTime) {
 	}
 }
 
-export function formatBorderColor(defaultStatus, routeStatus) {
-	if (defaultStatus === 'Departing') {
-		return {
-			borderColor: 'border-brand-gray'
-		};
-	}
-
-	if (routeStatus === 'early') {
-		return {
-			borderColor: 'border-brand-red'
-		};
-	}
-
-	if (routeStatus === 'late') {
-		return {
-			borderColor: 'border-brand-blue'
-		};
-	}
-
-	return {
-		borderColor: 'border-brand-lightgray'
-	};
-}
-
-export function formatShadowColor(defaultStatus, routeStatus) {
-	if (defaultStatus === 'Departing') {
-		return {
-			shadowColor: 'var(--shadow-gray)'
-		};
-	}
-
-	if (routeStatus === 'early') {
-		return {
-			shadowColor: 'var(--shadow-red)'
-		};
-	}
-
-	if (routeStatus === 'late') {
-		return {
-			shadowColor: 'var(--shadow-blue)'
-		};
-	}
-
-	return {
-		shadowColor: 'var(--shadow-gray)'
-	};
-}
-
-export function formatTextColor(defaultStatus, routeStatus) {
-	if (defaultStatus === 'Departing') {
-		return {
-			textColor: ''
-		};
-	}
-
-	if (routeStatus === 'early') {
-		return {
-			textColor: 'text-brand-red'
-		};
-	}
-
-	if (routeStatus === 'late') {
-		return {
-			textColor: 'text-brand-blue'
-		};
-	}
-
-	return {
-		textColor: 'text-brand-gray'
-	};
-}
-
-// Is the vehicle is early or late?
+/**
+ * Calculate early/late status compared to schedule
+ *
+ * @param {number} predictedTime - Predicted timestamp
+ * @param {number} scheduledTime - Scheduled timestamp
+ *
+ * @returns {Object} {status: string|null, tag: string|null}
+ */
 export function formatRouteStatus(predictedTime, scheduledTime) {
 	if (typeof predictedTime === 'undefined' || predictedTime === null || predictedTime === 0) {
 		return {
@@ -170,6 +112,102 @@ export function formatRouteStatus(predictedTime, scheduledTime) {
 	return {
 		status: 'on-time',
 		tag: null
+	};
+}
+
+/**
+ * Get border color class based on status
+ *
+ * @param {string} defaultStatus - Arrival status
+ * @param {string} routeStatus - Early/late status
+ *
+ * @returns {Object} {borderColor: string}
+ */
+export function formatBorderColor(defaultStatus, routeStatus) {
+	if (defaultStatus === 'Departing') {
+		return {
+			borderColor: 'border-brand-gray'
+		};
+	}
+
+	if (routeStatus === 'early') {
+		return {
+			borderColor: 'border-brand-red'
+		};
+	}
+
+	if (routeStatus === 'late') {
+		return {
+			borderColor: 'border-brand-blue'
+		};
+	}
+
+	return {
+		borderColor: 'border-brand-lightgray'
+	};
+}
+
+/**
+ * Get shadow color variable based on status
+ *
+ * @param {string} defaultStatus - Arrival status
+ * @param {string} routeStatus - Early/late status
+ *
+ * @returns {Object} {shadowColor: string}
+ */
+export function formatShadowColor(defaultStatus, routeStatus) {
+	if (defaultStatus === 'Departing') {
+		return {
+			shadowColor: 'var(--shadow-gray)'
+		};
+	}
+
+	if (routeStatus === 'early') {
+		return {
+			shadowColor: 'var(--shadow-red)'
+		};
+	}
+
+	if (routeStatus === 'late') {
+		return {
+			shadowColor: 'var(--shadow-blue)'
+		};
+	}
+
+	return {
+		shadowColor: 'var(--shadow-gray)'
+	};
+}
+
+/**
+ * Get text color class based on status
+ *
+ * @param {string} defaultStatus - Arrival status
+ * @param {string} routeStatus - Early/late status
+ *
+ * @returns {Object} {textColor: string}
+ */
+export function formatTextColor(defaultStatus, routeStatus) {
+	if (defaultStatus === 'Departing') {
+		return {
+			textColor: ''
+		};
+	}
+
+	if (routeStatus === 'early') {
+		return {
+			textColor: 'text-brand-red'
+		};
+	}
+
+	if (routeStatus === 'late') {
+		return {
+			textColor: 'text-brand-blue'
+		};
+	}
+
+	return {
+		textColor: 'text-brand-gray'
 	};
 }
 

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -70,48 +70,48 @@ export function formatArrivalStatus(predictedTime, scheduledTime) {
 export function formatBorderColor(defaultStatus, routeStatus) {
 	if (defaultStatus === 'Departing') {
 		return {
-			borderColor: 'border-[#8D8D8D]'
+			borderColor: 'border-brand-gray'
 		};
 	}
 
 	if (routeStatus === 'early') {
 		return {
-			borderColor: 'border-[#EB3223]'
+			borderColor: 'border-brand-red'
 		};
 	}
 
 	if (routeStatus === 'late') {
 		return {
-			borderColor: 'border-[#0087E8]'
+			borderColor: 'border-brand-blue'
 		};
 	}
 
 	return {
-		borderColor: 'border-[#00273B66]'
+		borderColor: 'border-brand-lightgray'
 	};
 }
 
 export function formatShadowColor(defaultStatus, routeStatus) {
 	if (defaultStatus === 'Departing') {
 		return {
-			shadowColor: 'rgba(0,0,0,0.08)'
+			shadowColor: 'var(--shadow-gray)'
 		};
 	}
 
 	if (routeStatus === 'early') {
 		return {
-			shadowColor: 'rgba(235,50,35,0.03)'
+			shadowColor: 'var(--shadow-red)'
 		};
 	}
 
 	if (routeStatus === 'late') {
 		return {
-			shadowColor: 'rgba(0,149,255,0.07)'
+			shadowColor: 'var(--shadow-blue)'
 		};
 	}
 
 	return {
-		shadowColor: 'rgba(0,0,0,0.08)'
+		shadowColor: 'var(--shadow-gray)'
 	};
 }
 
@@ -124,18 +124,18 @@ export function formatTextColor(defaultStatus, routeStatus) {
 
 	if (routeStatus === 'early') {
 		return {
-			textColor: 'text-[#EB3223]'
+			textColor: 'text-brand-red'
 		};
 	}
 
 	if (routeStatus === 'late') {
 		return {
-			textColor: 'text-[#0087E8]'
+			textColor: 'text-brand-blue'
 		};
 	}
 
 	return {
-		textColor: 'text-[#8D8D8D]'
+		textColor: 'text-brand-gray'
 	};
 }
 

--- a/src/lib/formatters.test.js
+++ b/src/lib/formatters.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { formatTime, formatTime2, formatDate, formatCurrentTime } from '$lib/formatters';
+import { formatDateTime, formatTime, formatDate, formatCurrentTime } from '$lib/formatters';
 
 describe('Formatter Utilities', () => {
 	beforeEach(() => {
@@ -10,48 +10,48 @@ describe('Formatter Utilities', () => {
 		vi.restoreAllMocks();
 	});
 
-	describe('formatTime', () => {
+	describe('formatDateTime', () => {
 		it('formats time with hours, minutes, and seconds', () => {
 			const date = new Date(2023, 0, 1, 13, 45, 30);
-			const formattedTime = formatTime(date);
+			const formattedTime = formatDateTime(date);
 			expect(formattedTime).toBe('1:45:30 PM');
 		});
 
 		it('handles midnight (12 AM) correctly', () => {
 			const date = new Date(2023, 0, 1, 0, 5, 15);
-			const formattedTime = formatTime(date);
+			const formattedTime = formatDateTime(date);
 			expect(formattedTime).toBe('12:05:15 AM');
 		});
 
 		it('handles noon (12 PM) correctly', () => {
 			const date = new Date(2023, 0, 1, 12, 0, 0);
-			const formattedTime = formatTime(date);
+			const formattedTime = formatDateTime(date);
 			expect(formattedTime).toBe('12:00:00 PM');
 		});
 	});
 
-	describe('formatTime2', () => {
+	describe('formatTime', () => {
 		it('formats time with hours and minutes only (no seconds)', () => {
 			const date = new Date(2023, 0, 1, 13, 45, 30);
-			const formattedTime = formatTime2(date);
+			const formattedTime = formatTime(date);
 			expect(formattedTime).toBe('1:45 PM');
 		});
 
 		it('handles midnight (12 AM) correctly', () => {
 			const date = new Date(2023, 0, 1, 0, 5, 15);
-			const formattedTime = formatTime2(date);
+			const formattedTime = formatTime(date);
 			expect(formattedTime).toBe('12:05 AM');
 		});
 
 		it('handles noon (12 PM) correctly', () => {
 			const date = new Date(2023, 0, 1, 12, 0, 0);
-			const formattedTime = formatTime2(date);
+			const formattedTime = formatTime(date);
 			expect(formattedTime).toBe('12:00 PM');
 		});
 
 		it('accepts string date input', () => {
 			const dateStr = '2023-01-01T13:45:30';
-			const formattedTime = formatTime2(dateStr);
+			const formattedTime = formatTime(dateStr);
 			expect(formattedTime).toBe('1:45 PM');
 		});
 	});
@@ -99,10 +99,10 @@ describe('Formatter Utilities', () => {
 			const timeStringSpy = vi.spyOn(Date.prototype, 'toLocaleTimeString');
 			const dateStringSpy = vi.spyOn(Date.prototype, 'toLocaleDateString');
 
-			formatTime(date);
+			formatDateTime(date);
 			expect(timeStringSpy).toHaveBeenCalledWith('en-US', expect.anything());
 
-			formatTime2(date);
+			formatTime(date);
 			expect(timeStringSpy).toHaveBeenCalledWith('en-US', expect.anything());
 
 			formatDate(date);


### PR DESCRIPTION
Refactored the departure display logic to improve maintainability and customization. Key changes include:

- Simplified `formatRouteStatus` to slightly follow the "single-responsibility" principle.
- Made departure block colors fully customizable via tailwindcss `@apply` directives and `@theme` variables.
- Separated styling from formatting logic to prevent collisions.
- Cleaned up redundant code and comments for better readability.

The changes maintain existing functionality while making future updates easier.