### PR TITLE
Added Service Worker

### DIFF
--- a/src/components/navigation/footer.svelte
+++ b/src/components/navigation/footer.svelte
@@ -1,6 +1,18 @@
 <script>
-	let { stops } = $props();
+	import { onMount } from 'svelte';
 	import * as t from '$lib/paraglide/messages.js';
+
+	let { stopIDs = [] } = $props();
+
+	let stops = $state([]);
+
+	async function stopNames() {
+		const response = await fetch(`/api/oba/name-and-code-for-stop/${stopIDs.join('+')}`);
+		const dataBlocks = await response.json();
+		stops = dataBlocks;
+	}
+
+	onMount(stopNames);
 </script>
 
 <div class="flex items-center justify-between bg-gray-300 p-[0.625vw] text-black">

--- a/src/components/navigation/footer.test.js
+++ b/src/components/navigation/footer.test.js
@@ -1,37 +1,46 @@
 // @vitest-environment jsdom
 
-import { render, cleanup } from '@testing-library/svelte';
-import { describe, test, expect, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/svelte';
+import { describe, test, expect, afterEach, vi } from 'vitest';
 import Footer from './footer.svelte';
 
 afterEach(() => {
 	cleanup();
+	vi.restoreAllMocks();
 });
 
 describe('Footer', () => {
-	test('renders successfully with one stop', () => {
-		const stops = [{ code: '262626', name: 'Stop Test Example' }];
-
-		const { container } = render(Footer, {
-			props: { stops }
+	test('renders successfully with one stop', async () => {
+		vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+			json: async () => [{ code: '262626', name: 'Stop Test Example' }]
 		});
 
-		expect(container.innerHTML).toContain('Waystation by Open Transit Software Foundation');
-		expect(container.innerHTML).toContain('Stop No. 262626 - Stop Test Example');
+		const { container } = render(Footer, {
+			props: { stopIDs: ['262626'] }
+		});
+
+		await waitFor(() => {
+			expect(container.innerHTML).toContain('Waystation by Open Transit Software Foundation');
+			expect(container.innerHTML).toContain('Stop No. 262626 - Stop Test Example');
+		});
 	});
 
-	test('renders multiple stops separated by dots', () => {
-		const stops = [
-			{ code: '262', name: 'Stop A' },
-			{ code: '626', name: 'Stop B' }
-		];
-
-		const { container } = render(Footer, {
-			props: { stops }
+	test('renders multiple stops separated by dots', async () => {
+		vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+			json: async () => [
+				{ code: '262', name: 'Stop A' },
+				{ code: '626', name: 'Stop B' }
+			]
 		});
 
-		expect(container.innerHTML).toContain('Stop No. 262 - Stop A');
-		expect(container.innerHTML).toContain('Stop No. 626 - Stop B');
-		expect(container.innerHTML).toContain('•');
+		const { container } = render(Footer, {
+			props: { stopIDs: ['262', '626'] }
+		});
+
+		await waitFor(() => {
+			expect(container.innerHTML).toContain('Stop No. 262 - Stop A');
+			expect(container.innerHTML).toContain('Stop No. 626 - Stop B');
+			expect(container.innerHTML).toContain('•');
+		});
 	});
 });

--- a/src/routes/api/oba/arrivals-and-departures-for-stop/[id]/+server.js
+++ b/src/routes/api/oba/arrivals-and-departures-for-stop/[id]/+server.js
@@ -1,8 +1,32 @@
-import oba, { handleOBAResponse } from '$lib/obaSdk.js';
+import oba from '$lib/obaSdk';
+import { error } from '@sveltejs/kit';
 
-/** @type {import('./$types').RequestHandler} */
+const cache = new Map();
+
 export async function GET({ params }) {
 	const stopID = params.id;
-	const response = await oba.arrivalAndDeparture.list(stopID);
-	return handleOBAResponse(response, 'arrivals-and-departures-for-stop');
+
+	try {
+		const response = await oba.arrivalAndDeparture.list(stopID);
+
+		cache.set(stopID, response);
+
+		return new Response(JSON.stringify(response), {
+			headers: { 'Content-Type': 'application/json' }
+		});
+	} catch (err) {
+		console.warn(`OBA fetch failed for stop ${stopID}:, ${err.message}`);
+
+		if (cache.has(stopID)) {
+			return new Response(
+				JSON.stringify({
+					...cache.get(stopID),
+					stale: true
+				}),
+				{ headers: { 'Content-Type': 'application/json' } }
+			);
+		}
+
+		throw error(503, `No data available for stop ${stopID}`);
+	}
 }

--- a/src/routes/api/oba/name-and-code-for-stop/[id]/+server.js
+++ b/src/routes/api/oba/name-and-code-for-stop/[id]/+server.js
@@ -1,0 +1,39 @@
+import oba, { handleOBAResponse } from '$lib/obaSdk.js';
+import { error } from '@sveltejs/kit';
+
+const cache = new Map();
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ params }) {
+	const stopIDs = params.id.split('+');
+
+	try {
+		const stopResponses = await Promise.all(stopIDs.map((eachID) => oba.stop.retrieve(eachID)));
+
+		const stopBodies = await Promise.all(
+			stopResponses.map((eachResponse) => handleOBAResponse(eachResponse, 'stop').json())
+		);
+
+		const dataBlocks = stopBodies.map((stopBody) => stopBody.data.entry);
+
+		stopIDs.forEach((id, i) => {
+			cache.set(id, stopBodies[i]);
+		});
+
+		return new Response(JSON.stringify(dataBlocks), {
+			headers: { 'Content-Type': 'application/json' }
+		});
+	} catch (err) {
+		console.warn(`OBA fetch failed for stops [${stopIDs.join(', ')}]: ${err.message}`);
+
+		if (stopIDs.every((id) => cache.has(id))) {
+			const cachedBlocks = stopIDs.map((id) => cache.get(id).data.entry);
+
+			return new Response(JSON.stringify(cachedBlocks.map((b) => ({ ...b, stale: true }))), {
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+
+		throw error(503, `No data available for stops [${stopIDs.join(', ')}]`);
+	}
+}

--- a/src/routes/stops/[stopID]/+page.server.js
+++ b/src/routes/stops/[stopID]/+page.server.js
@@ -1,15 +1,7 @@
-import oba, { handleOBAResponse } from '$lib/obaSdk.js';
-
 export async function load({ params }) {
 	const stopIDs = params.stopID.split('+');
 
-	const stopResponses = await Promise.all(stopIDs.map((eachID) => oba.stop.retrieve(eachID)));
-	const stopBodies = await Promise.all(
-		stopResponses.map((eachResponse) => handleOBAResponse(eachResponse, 'stop').json())
-	);
-
 	return {
-		stopIDs,
-		dataBlocks: stopBodies.map((stopData) => stopData.data)
+		stopIDs
 	};
 }

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -6,12 +6,11 @@
 	import Footer from '$components/navigation/footer.svelte';
 
 	let { data } = $props();
-
-	const stops = data.dataBlocks.map((eachBlock) => eachBlock.entry);
 </script>
 
 <div class="flex h-screen flex-col">
 	<Header title={PUBLIC_OBA_REGION_NAME} imageUrl={PUBLIC_OBA_LOGO_URL} />
+
 	<div class="flex flex-1 gap-4 overflow-hidden">
 		<div class="flex-1 overflow-y-auto">
 			<Controller stopIDs={data.stopIDs} />
@@ -19,6 +18,6 @@
 	</div>
 
 	<div id="footer">
-		<Footer {stops} class="shrink-0" />
+		<Footer stopIDs={data.stopIDs} class="shrink-0" />
 	</div>
 </div>


### PR DESCRIPTION
- Added Service Worker support to cache OBA API responses, improving resilience when the server is unavailable.
- Moved OBA arrivals/departures fetching from server-side to client-side.
- Refactored the footer component to be fully self-contained, fetching stop names and codes internally.
- Updated and simplified the footer unit test to reflect the new client-side fetching behavior.