### PR TITLE
Cycle through all situations instead of the first one only

### DIFF
--- a/src/components/alerts/alerts.svelte
+++ b/src/components/alerts/alerts.svelte
@@ -9,9 +9,15 @@
 
 	let title = $state('');
 	let translatedTitle = $state('');
+	let dateStart = $state('');
+	let dateEnd = $state('');
 
 	$effect(() => {
+		const activeWindow = situation?.activeWindows?.[0];
+
 		title = situation?.summary?.value?.trim?.() ?? '';
+		dateStart = formatTimestamp(activeWindow?.from);
+		dateEnd = formatTimestamp(activeWindow?.to);
 
 		if (getLocale() !== 'en') {
 			translate(title, getLocale()).then((result) => {
@@ -19,10 +25,6 @@
 			});
 		}
 	});
-
-	const activeWindow = situation?.activeWindows?.[0];
-	const dateStart = formatTimestamp(activeWindow?.from);
-	const dateEnd = formatTimestamp(activeWindow?.to);
 </script>
 
 {#if displayMode}

--- a/src/components/alerts/alerts.svelte
+++ b/src/components/alerts/alerts.svelte
@@ -5,12 +5,14 @@
 
 	import * as t from '$lib/paraglide/messages.js';
 
-	let { situations = [], displayMode } = $props();
+	let { situation = {}, displayMode } = $props();
 
-	let title = $state(situations[0]?.summary?.value?.trim?.() ?? '');
-	let translatedTitle = $state(title);
+	let title = $state('');
+	let translatedTitle = $state('');
 
 	$effect(() => {
+		title = situation?.summary?.value?.trim?.() ?? '';
+
 		if (getLocale() !== 'en') {
 			translate(title, getLocale()).then((result) => {
 				translatedTitle = result;
@@ -18,7 +20,7 @@
 		}
 	});
 
-	const activeWindow = situations[0]?.activeWindows?.[0];
+	const activeWindow = situation?.activeWindows?.[0];
 	const dateStart = formatTimestamp(activeWindow?.from);
 	const dateEnd = formatTimestamp(activeWindow?.to);
 </script>

--- a/src/components/alerts/alerts.svelte
+++ b/src/components/alerts/alerts.svelte
@@ -16,10 +16,11 @@
 		const activeWindow = situation?.activeWindows?.[0];
 
 		title = situation?.summary?.value?.trim?.() ?? '';
+		translatedTitle = '';
 		dateStart = formatTimestamp(activeWindow?.from);
 		dateEnd = formatTimestamp(activeWindow?.to);
 
-		if (getLocale() !== 'en') {
+		if (title && getLocale() !== 'en') {
 			translate(title, getLocale()).then((result) => {
 				translatedTitle = result;
 			});

--- a/src/components/alerts/alerts.svelte
+++ b/src/components/alerts/alerts.svelte
@@ -21,9 +21,13 @@
 		dateEnd = formatTimestamp(activeWindow?.to);
 
 		if (title && getLocale() !== 'en') {
-			translate(title, getLocale()).then((result) => {
-				translatedTitle = result;
-			});
+			translate(title, getLocale())
+				.then((result) => {
+					translatedTitle = result;
+				})
+				.catch(() => {
+					translatedTitle = title;
+				});
 		}
 	});
 </script>

--- a/src/components/alerts/alerts.test.js
+++ b/src/components/alerts/alerts.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, cleanup } from '@testing-library/svelte';
+import { render, cleanup, waitFor } from '@testing-library/svelte';
 import { expect, test, describe, afterEach } from 'vitest';
 import Alerts from './alerts.svelte';
 import * as t from '$lib/paraglide/messages.js';
@@ -10,120 +10,97 @@ describe('Alerts component in displayMode (sidebar mode)', () => {
 		cleanup();
 	});
 
-	test('renders alert with equal valid start and end dates', () => {
+	test('renders alert with equal valid start and end dates', async () => {
 		const { getByText, queryByText, container } = render(Alerts, {
 			props: {
-				situations: [
-					{
-						summary: { value: 'Test Alert Title' },
-						activeWindows: [
-							{
-								from: 1718948400000,
-								to: 1718948400000
-							}
-						]
-					}
-				],
+				situation: {
+					summary: { value: 'Test Alert Title' },
+					activeWindows: [{ from: 1718948400000, to: 1718948400000 }]
+				},
 				displayMode: true
 			}
 		});
 
-		expect(getByText(t.alerts_disclaimer())).toBeTruthy();
-		expect(getByText('Test Alert Title')).toBeTruthy();
-		expect(getByText(t.alerts_on())).toBeTruthy();
-		expect(container.innerHTML).not.toContain('➔');
-		expect(queryByText(t.alerts_starting())).toBeNull();
-		expect(queryByText(t.alerts_ending())).toBeNull();
+		await waitFor(() => {
+			expect(getByText(t.alerts_disclaimer())).toBeTruthy();
+			expect(getByText('Test Alert Title')).toBeTruthy();
+			expect(getByText(t.alerts_on())).toBeTruthy();
+			expect(container.innerHTML).not.toContain('➔');
+			expect(queryByText(t.alerts_starting())).toBeNull();
+			expect(queryByText(t.alerts_ending())).toBeNull();
+		});
 	});
 
-	test('renders alert with only start date', () => {
+	test('renders alert with only start date', async () => {
 		const { getByText, queryByText, container } = render(Alerts, {
 			props: {
-				situations: [
-					{
-						summary: { value: 'Test Alert Title' },
-						activeWindows: [
-							{
-								from: 1718948400000
-							}
-						]
-					}
-				],
+				situation: {
+					summary: { value: 'Test Alert Title' },
+					activeWindows: [{ from: 1718948400000 }]
+				},
 				displayMode: true
 			}
 		});
 
-		expect(getByText(t.alerts_starting())).toBeTruthy();
-		expect(queryByText(t.alerts_ending())).toBeNull();
-		expect(container.innerHTML).not.toContain('➔');
+		await waitFor(() => {
+			expect(getByText(t.alerts_starting())).toBeTruthy();
+			expect(queryByText(t.alerts_ending())).toBeNull();
+			expect(container.innerHTML).not.toContain('➔');
+		});
 	});
 
-	test('renders alert with only end date', () => {
+	test('renders alert with only end date', async () => {
 		const { getByText, queryByText, container } = render(Alerts, {
 			props: {
-				situations: [
-					{
-						summary: { value: 'Test Alert Title' },
-						activeWindows: [
-							{
-								to: 1718952000000
-							}
-						]
-					}
-				],
+				situation: {
+					summary: { value: 'Test Alert Title' },
+					activeWindows: [{ to: 1718952000000 }]
+				},
 				displayMode: true
 			}
 		});
 
-		expect(queryByText(t.alerts_starting())).toBeNull();
-		expect(getByText(t.alerts_ending())).toBeTruthy();
-		expect(container.innerHTML).not.toContain('➔');
+		await waitFor(() => {
+			expect(queryByText(t.alerts_starting())).toBeNull();
+			expect(getByText(t.alerts_ending())).toBeTruthy();
+			expect(container.innerHTML).not.toContain('➔');
+		});
 	});
 
-	test('renders alert with both valid but different dates', () => {
+	test('renders alert with both valid but different dates', async () => {
 		const { getByText, container } = render(Alerts, {
 			props: {
-				situations: [
-					{
-						summary: { value: 'Test Alert Title' },
-						activeWindows: [
-							{
-								from: 1718948400000,
-								to: 1318952000000
-							}
-						]
-					}
-				],
+				situation: {
+					summary: { value: 'Test Alert Title' },
+					activeWindows: [{ from: 1718948400000, to: 1318952000000 }]
+				},
 				displayMode: true
 			}
 		});
 
-		expect(getByText(t.alerts_starting())).toBeTruthy();
-		expect(getByText(t.alerts_ending())).toBeTruthy();
-		expect(container.textContent).toContain('➔');
+		await waitFor(() => {
+			expect(getByText(t.alerts_starting())).toBeTruthy();
+			expect(getByText(t.alerts_ending())).toBeTruthy();
+			expect(container.textContent).toContain('➔');
+		});
 	});
 
-	test('does not render any date-related text for invalid timestamps', () => {
+	test('does not render any date-related text for invalid timestamps', async () => {
 		const { queryByText, container } = render(Alerts, {
 			props: {
-				situations: [
-					{
-						summary: { value: 'Test Alert Title' },
-						activeWindows: [
-							{
-								from: 'invalid',
-								to: 'invalid'
-							}
-						]
-					}
-				],
+				situation: {
+					summary: { value: 'Test Alert Title' },
+					activeWindows: [{ from: 'invalid', to: 'invalid' }]
+				},
 				displayMode: true
 			}
 		});
 
-		expect(queryByText(t.alerts_on())).toBeNull();
-		expect(queryByText(t.alerts_starting())).toBeNull();
-		expect(queryByText(t.alerts_ending())).toBeNull();
-		expect(container.innerHTML).not.toContain('➔');
+		await waitFor(() => {
+			expect(queryByText(t.alerts_on())).toBeNull();
+			expect(queryByText(t.alerts_starting())).toBeNull();
+			expect(queryByText(t.alerts_ending())).toBeNull();
+			expect(container.innerHTML).not.toContain('➔');
+		});
 	});
 });

--- a/src/components/controller/controller.svelte
+++ b/src/components/controller/controller.svelte
@@ -15,6 +15,7 @@
 
 	let { stopIDs = [] } = $props();
 
+	let alertIndex = $state(0);
 	let footerHeight = $state(0);
 	let sideDisplay = $state(false);
 
@@ -26,6 +27,12 @@
 		config,
 		REFRESH_INTERVAL = 30_000,
 		MAX_DEPARTURES = 99;
+
+	function cycleAlerts() {
+		if (situations.length >= 2) {
+			alertIndex = (alertIndex + 1) % situations.length;
+		}
+	}
 
 	function stopRequestDataModel(dep, stopID, stopName) {
 		const status = formatArrivalStatus(dep.predictedDepartureTime, dep.scheduledDepartureTime);
@@ -84,6 +91,8 @@
 			allDepartures = removeDuplicates(allDepartures);
 			allDepartures = sortEarliestDepartures(allDepartures);
 			allDepartures = allDepartures.slice(0, MAX_DEPARTURES);
+
+			cycleAlerts();
 		} catch (error) {
 			console.error('Error fetching stops:', error);
 			allDepartures = [];
@@ -139,11 +148,11 @@
 	{#if situations.length > 0 && situations[0].summary?.value && allDepartures.length > 0}
 		{#if sideDisplay}
 			<div class="flex-shrink-0 basis-[35%] overflow-y-auto">
-				<Alerts {situations} displayMode={sideDisplay} />
+				<Alerts situation={situations[alertIndex]} displayMode={sideDisplay} />
 			</div>
 		{:else}
 			<div class="fixed" style={`bottom: ${footerHeight}px`}>
-				<Alerts {situations} displayMode={sideDisplay} />
+				<Alerts situation={situations[alertIndex]} displayMode={sideDisplay} />
 			</div>
 		{/if}
 	{/if}

--- a/src/components/controller/controller.svelte
+++ b/src/components/controller/controller.svelte
@@ -15,7 +15,7 @@
 
 	let { stopIDs = [] } = $props();
 
-	let alertIndex = $state(0);
+	let alertIndex = $state(-1);
 	let footerHeight = $state(0);
 	let sideDisplay = $state(false);
 
@@ -30,7 +30,7 @@
 
 	function cycleAlerts() {
 		if (situations.length === 0) {
-			alertIndex = 0;
+			alertIndex = -1;
 			return;
 		}
 		alertIndex = (alertIndex + 1) % situations.length;

--- a/src/components/controller/controller.svelte
+++ b/src/components/controller/controller.svelte
@@ -147,7 +147,7 @@
 		{/if}
 	</div>
 
-	{#if situations.length > 0 && situations[alertIndex].summary?.value && allDepartures.length > 0}
+	{#if situations.length > 0 && situations[Math.max(0, alertIndex)].summary?.value && allDepartures.length > 0}
 		{#if sideDisplay}
 			<div class="flex-shrink-0 basis-[35%] overflow-y-auto">
 				<Alerts situation={situations[Math.max(0, alertIndex)]} displayMode={sideDisplay} />

--- a/src/components/controller/controller.svelte
+++ b/src/components/controller/controller.svelte
@@ -147,7 +147,7 @@
 		{/if}
 	</div>
 
-	{#if situations.length > 0 && situations[0].summary?.value && allDepartures.length > 0}
+	{#if situations.length > 0 && situations[alertIndex].summary?.value && allDepartures.length > 0}
 		{#if sideDisplay}
 			<div class="flex-shrink-0 basis-[35%] overflow-y-auto">
 				<Alerts situation={situations[Math.max(0, alertIndex)]} displayMode={sideDisplay} />

--- a/src/components/controller/controller.svelte
+++ b/src/components/controller/controller.svelte
@@ -150,11 +150,11 @@
 	{#if situations.length > 0 && situations[0].summary?.value && allDepartures.length > 0}
 		{#if sideDisplay}
 			<div class="flex-shrink-0 basis-[35%] overflow-y-auto">
-				<Alerts situation={situations[alertIndex]} displayMode={sideDisplay} />
+				<Alerts situation={situations[Math.max(0, alertIndex)]} displayMode={sideDisplay} />
 			</div>
 		{:else}
 			<div class="fixed" style={`bottom: ${footerHeight}px`}>
-				<Alerts situation={situations[alertIndex]} displayMode={sideDisplay} />
+				<Alerts situation={situations[Math.max(0, alertIndex)]} displayMode={sideDisplay} />
 			</div>
 		{/if}
 	{/if}

--- a/src/components/controller/controller.svelte
+++ b/src/components/controller/controller.svelte
@@ -29,9 +29,11 @@
 		MAX_DEPARTURES = 99;
 
 	function cycleAlerts() {
-		if (situations.length >= 2) {
-			alertIndex = (alertIndex + 1) % situations.length;
+		if (situations.length === 0) {
+			alertIndex = 0;
+			return;
 		}
+		alertIndex = (alertIndex + 1) % situations.length;
 	}
 
 	function stopRequestDataModel(dep, stopID, stopName) {

--- a/src/components/controller/controller.test.js
+++ b/src/components/controller/controller.test.js
@@ -58,3 +58,90 @@ test('renders a departure after fetching', async () => {
 		expect(getByText('Test Stop')).toBeTruthy();
 	});
 });
+
+test('cycles through situations on 2+ fetches', async () => {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(() =>
+			Promise.resolve({
+				json: () =>
+					Promise.resolve({
+						data: {
+							entry: {
+								arrivalsAndDepartures: [
+									{
+										predictedDepartureTime: Date.now() + 5 * 60_000,
+										scheduledDepartureTime: Date.now() + 7 * 60_000,
+										tripId: 'trip1',
+										stopId: 'agency_123',
+										routeShortName: '10',
+										tripHeadsign: 'Test Trip',
+										stopName: 'Test Stop'
+									}
+								]
+							},
+							references: {
+								stops: {
+									agency_123: { id: 'agency_123', name: 'Test Stop' }
+								},
+								situations: [
+									{
+										summary: {
+											lang: 'en',
+											value:
+												'Conan Gray tonight at Climate Pledge Arena, starts 8:00 p.m. Please plan ahead for additional travel time.'
+										}
+									},
+									{
+										summary: {
+											lang: 'en',
+											value:
+												'Northgate Station Garage will be closed for maintenance Saturday, March 21 and Sunday, March 22.'
+										}
+									},
+									{
+										summary: {
+											lang: 'en',
+											value:
+												'Angle Lake Garage elevator 2 unavailable until further notice due to unscheduled outage. Please use adjacent elevator.'
+										}
+									}
+								]
+							}
+						}
+					})
+			})
+		)
+	);
+
+	document.getElementById = vi.fn().mockImplementation((id) => {
+		if (id === 'footer') return { offsetHeight: 50 };
+		return null;
+	});
+
+	const { component, getByText } = render(Controller, { props: { stopIDs: ['agency_123'] } });
+
+	await waitFor(() => {
+		expect(getByText('Test Trip')).toBeTruthy();
+		expect(getByText('Test Stop')).toBeTruthy();
+		expect(getByText(/Conan Gray/)).toBeTruthy();
+	});
+
+	await component.fetchStops();
+
+	await waitFor(() => {
+		expect(getByText(/Northgate Station Garage will/)).toBeTruthy();
+	});
+
+	await component.fetchStops();
+
+	await waitFor(() => {
+		expect(getByText(/Angle Lake Garage elevator 2/)).toBeTruthy();
+	});
+
+	await component.fetchStops();
+
+	await waitFor(() => {
+		expect(getByText(/Conan Gray/)).toBeTruthy();
+	});
+});


### PR DESCRIPTION
Fixes #55 

- Display all situations/alerts instead of only the first one by cycling through them on each refresh interval
- Change the Alerts component to accept a single `situation` object instead of a `situations` array, with the parent controller managing which one to show
- Move date and title logic into `$effect` so the component reacts when the situation changes
- Update tests to pass a single `situation` object and wrap assertions in `waitFor` to account for Svelte 5's async reactivity