### PR TITLE
fix: prevent Svelte branch-switch crash on stops page with wide screens and active alerts

### DIFF
--- a/src/components/controller/controller.svelte
+++ b/src/components/controller/controller.svelte
@@ -19,6 +19,10 @@
 	let footerHeight = $state(0);
 	let sideDisplay = $state(false);
 
+	$effect(() => {
+		sideDisplay = window.innerWidth > 1680;
+	});
+
 	let allDepartures = $state([]);
 	let situations = $state([]);
 	let loading = $state(true);
@@ -114,7 +118,6 @@
 
 		if (browser) {
 			clearInterval(interval);
-			sideDisplay = window.innerWidth > 1680;
 			interval = setInterval(fetchStops, REFRESH_INTERVAL);
 			const footer = document.getElementById('footer');
 			if (footer) footerHeight = footer.offsetHeight;

--- a/src/components/controller/controller.test.js
+++ b/src/components/controller/controller.test.js
@@ -145,3 +145,51 @@ test('cycles through situations on 2+ fetches', async () => {
 		expect(getByText(/Conan Gray/)).toBeTruthy();
 	});
 });
+
+test('renders side-display alerts without crashing on wide screens', async () => {
+	// Regression test: on wide screens sideDisplay flips true after the fetch completes,
+	// which previously caused a Svelte branch-switch crash in destroy_effect → get_next_sibling.
+	vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1800);
+
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(() =>
+			Promise.resolve({
+				json: () =>
+					Promise.resolve({
+						data: {
+							entry: {
+								arrivalsAndDepartures: [
+									{
+										predictedDepartureTime: Date.now() + 5 * 60_000,
+										scheduledDepartureTime: Date.now() + 7 * 60_000,
+										tripId: 'trip1',
+										stopId: 'agency_123',
+										routeShortName: '10',
+										tripHeadsign: 'Test Trip',
+										stopName: 'Test Stop'
+									}
+								]
+							},
+							references: {
+								stops: { agency_123: { id: 'agency_123', name: 'Test Stop' } },
+								situations: [{ summary: { lang: 'en', value: 'Test service alert' } }]
+							}
+						}
+					})
+			})
+		)
+	);
+
+	document.getElementById = vi.fn().mockImplementation((id) => {
+		if (id === 'footer') return { offsetHeight: 50 };
+		return null;
+	});
+
+	const { getByText } = render(Controller, { props: { stopIDs: ['agency_123'] } });
+
+	await waitFor(() => {
+		expect(getByText('Test Trip')).toBeTruthy();
+		expect(getByText('Test service alert')).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## Summary

- Moving `sideDisplay` from `onMount` to a `$effect` fixes a crash on the `/stops/[id]` page when a wide screen (>1680px) and active service alerts are both present
- Adds a regression test covering the wide-screen + situations scenario

## Root cause

When the OBA API returned both departures and situations, Svelte flushed the UI in two separate microtask cycles:

1. **Flush F1** (fetch completes): `situations` and `allDepartures` become non-empty → the alerts `{#if situations...}` block renders for the first time with `sideDisplay=false`, picking the `{:else}` branch
2. **Flush F2** (`sideDisplay` set in `onMount` continuation after `await fetchStops()`): `sideDisplay` flips to `true` → Svelte switches the inner `{#if sideDisplay}` branch → calls `destroy_effect` on the just-created `{:else}` branch before its anchor nodes were committed → crash: `Cannot read properties of undefined (reading 'call')` in `get_next_sibling`

## Fix

`$effect` runs before `onMount`'s async fetch yields, so `sideDisplay` is already at its correct value when situations first appear. The alerts block renders the right branch on first paint — no switch, no crash.

## Test plan

- [x] Run `npm test` — 35 tests pass
- [ ] Load `/stops/<id>` on a monitor wider than 1680px with a stop that has active service alerts — should render without console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout switching to properly respond to window width changes when resizing the browser window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/waystation/pull/70)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->