### PR TITLE
Add client-side typeahead search to agency stops page

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,30 @@
 	let stops = $derived(data.stops);
 	let stopIDs = $derived(data.stopIDs);
 	let selectedAgency = $derived(agencies.find((a) => a.id === selectedAgencyId));
+
+	let query = $state('');
+	$effect(() => {
+		selectedAgencyId;
+		query = '';
+	});
+
+	let normalizedQuery = $derived(query.trim().toLowerCase());
+
+	function matchesStop(stop) {
+		return (
+			stop.id.toLowerCase().includes(normalizedQuery) ||
+			(stop.name ?? '').toLowerCase().includes(normalizedQuery)
+		);
+	}
+
+	function matchesStopID(id) {
+		return id.toLowerCase().includes(normalizedQuery);
+	}
+
+	let filteredStops = $derived(normalizedQuery ? (stops?.filter(matchesStop) ?? []) : stops);
+	let filteredStopIDs = $derived(normalizedQuery ? stopIDs.filter(matchesStopID) : stopIDs);
+	let totalCount = $derived(stops ? stops.length : stopIDs.length);
+	let visibleCount = $derived(stops ? filteredStops.length : filteredStopIDs.length);
 </script>
 
 <div class="flex h-screen overflow-hidden bg-gray-50">
@@ -27,15 +51,30 @@
 			</div>
 		{:else}
 			<div class="flex-1 overflow-y-auto">
-				<div class="border-b border-gray-200 bg-white px-6 py-4">
-					<h1 class="text-base font-semibold text-gray-900">{selectedAgency.name}</h1>
-					<p class="text-sm text-gray-500">{stopIDs.length} stops</p>
+				<div class="space-y-3 border-b border-gray-200 bg-white px-6 py-4">
+					<div>
+						<h1 class="text-base font-semibold text-gray-900">{selectedAgency.name}</h1>
+						<p class="text-sm text-gray-500">
+							{#if normalizedQuery}
+								{visibleCount} of {totalCount} stops
+							{:else}
+								{totalCount} stops
+							{/if}
+						</p>
+					</div>
+					<input
+						type="search"
+						bind:value={query}
+						placeholder="Search stops…"
+						aria-label="Search stops"
+						class="focus:border-brand-blue focus:ring-brand-blue/20 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:ring-2 focus:outline-none"
+					/>
 				</div>
 				<div class="px-6 py-4">
 					{#if stops}
-						<StopTable {stops} />
+						<StopTable stops={filteredStops} />
 					{:else}
-						<StopIdTable {stopIDs} />
+						<StopIdTable stopIDs={filteredStopIDs} />
 					{/if}
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Adds a full-width search input on its own row below the agency name/count, filtering the already-loaded stops by ID and name (case-insensitive `includes`) as the user types.
- Works for both data shapes the server load can return: the rich `stops` array (ID + name) and the fallback `stopIDs` array (ID only, when the OBA server doesn't support `stopsForAgency`).
- Resets the query automatically when the user switches agencies via a `$effect` watching `selectedAgencyId`.
- Header shows `"N of M stops"` while filtering, `"M stops"` otherwise.

## Test plan
- [x] Load `/?agency=MTS`, confirm header shows `"6155 stops"` and search bar sits on its own row.
- [x] Type `Garnet` — list filters to 31 rows, header shows `"31 of 6155 stops"`, all visible rows match.
- [x] Type `MTS_10003` — list filters to one row (ID-only match).
- [x] Type a non-matching string — `"No stops found"` empty state.
- [x] Clear the input — full list (6155 rows) returns.
- [x] Switch agencies in the sidebar — query clears and header drops the `"X of Y"` prefix.
- [x] `npm run check` and `npm run lint` both clean.

## Review notes (non-blocking)
Surfaced by the multi-agent PR review pass; raising for your call rather than churning the diff:

- **`$effect` vs `{#key selectedAgencyId}` for query reset.** Code-reviewer prefers `{#key}` as the more idiomatic Svelte 5 pattern. I deliberately kept `$effect` because `{#key}` would remount the `<input>` on every agency switch (focus loss, slight flicker). Happy to flip if you'd rather have the idiom.
- **`aria-live` on the count.** The `"X of Y stops"` text updates silently as you type; adding `aria-live="polite"` to the `<p>` would let screen readers announce filter feedback. Trivial follow-up if you want it.
- **Extract filter into `formatters.js` + unit tests.** Test-analyzer suggested pulling `matchesStop` / `matchesStopID` into `$lib/formatters.js` for direct unit-test coverage (case-insensitivity, whitespace-only query, missing `name`, etc.). Deferred — feels heavy for ~30 lines of UI glue already covered by browser smoke testing.
- **Pre-existing: `+page.server.js` swallows upstream errors silently.** Silent-failure-hunter flagged that `stopsForAgency` and `stopIdsForAgency` catch and return `null`/`[]` with no surfaced error, so a real outage looks identical to an unsupported endpoint. Out of scope for this PR but worth a follow-up issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client-side search functionality to the stops view. Users can now search and filter stops by ID or name. The search interface displays a count of matching stops versus the total available, with results updating instantly to enable quick and efficient stop discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/waystation/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->