### PR TITLE
Redesign stop display as Solari-style departure board

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -26,3 +26,197 @@ body::before {
 	--shadow-gray: 0 0 0.52vw 0.52vw rgba(0, 0, 0, 0.08);
 	--color-oba-green: oklch(0.692 0.1728 138.8);
 }
+
+/* =========================================================
+   Waystation — Departure Board theme (Light + Dark)
+   Designed at 1920×1080 (landscape kiosk).
+   Light mode reads cleanly on e-ink; Dark mode glows like a Solari board.
+   ========================================================= */
+
+body.board-body {
+	margin: 0;
+	padding: 0;
+	background: #000;
+	overflow: hidden;
+	width: 100vw;
+	height: 100vh;
+	font-family: 'IBM Plex Sans', system-ui, sans-serif;
+}
+body.board-body::before {
+	display: none;
+}
+
+.board-stage-wrap {
+	position: fixed;
+	inset: 0;
+	background: #000;
+	overflow: hidden;
+}
+.board-stage {
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 1920px;
+	height: 1080px;
+	transform-origin: 0 0;
+	overflow: hidden;
+}
+
+.theme-departure {
+	font-family: 'IBM Plex Sans', system-ui, sans-serif;
+	background: var(--bg);
+	color: var(--ink);
+}
+.theme-departure .mono {
+	font-family: 'IBM Plex Mono', ui-monospace, monospace;
+	font-variant-numeric: tabular-nums;
+}
+.theme-departure .display {
+	font-family: 'IBM Plex Sans Condensed', 'IBM Plex Sans', sans-serif;
+	font-feature-settings: 'ss01';
+}
+
+/* THEME — DARK (Solari split-flap glow) */
+.theme-departure.theme-dark {
+	--bg: #0e1014;
+	--bg-elev: #15181f;
+	--rule: #2a2f3a;
+	--rule-strong: #3d4453;
+	--ink: #f4ecd8;
+	--ink-dim: #9b9685;
+	--ink-mute: #5e5a4f;
+	--accent: #d4b14a;
+	--accent-dim: #8a7530;
+	--badge-bg-1: #1a1d24;
+	--badge-bg-2: #14171c;
+	--badge-edge: #3d4453;
+	--badge-ink: #d4b14a;
+	--ontime: #7bdc8a;
+	--early: #ffb14a;
+	--late: #ff8b6a;
+	--cancel: #ff8b6a;
+	--sched: #9bb6d9;
+}
+
+/* THEME — LIGHT (paper timetable; reads on e-ink) */
+.theme-departure.theme-light {
+	--bg: #f5f3ee;
+	--bg-elev: #ffffff;
+	--rule: #c7c4bd;
+	--rule-strong: #1a1a1a;
+	--ink: #0a0a0a;
+	--ink-dim: #3a3a3a;
+	--ink-mute: #6a6a6a;
+	--accent: #0a0a0a;
+	--accent-dim: #3a3a3a;
+	--badge-bg-1: #ffffff;
+	--badge-bg-2: #ebe9e3;
+	--badge-edge: #0a0a0a;
+	--badge-ink: #0a0a0a;
+	--ontime: var(--ink);
+	--early: var(--ink);
+	--late: var(--ink);
+	--cancel: var(--ink);
+	--sched: var(--ink);
+}
+
+.theme-departure .status-ONTIME {
+	--status-tone: var(--ontime);
+}
+.theme-departure .status-EARLY {
+	--status-tone: var(--early);
+}
+.theme-departure .status-LATE {
+	--status-tone: var(--late);
+}
+.theme-departure .status-CANCEL {
+	--status-tone: var(--cancel);
+}
+.theme-departure .status-SCHED {
+	--status-tone: var(--sched);
+}
+
+.theme-departure .tnum {
+	font-variant-numeric: tabular-nums;
+}
+.theme-departure .sc {
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+.theme-departure .canceled-time {
+	text-decoration: line-through;
+	text-decoration-thickness: 0.08em;
+}
+
+.theme-departure .alert-badge {
+	border: 1px solid var(--rule);
+	background: var(--bg-elev);
+	color: var(--ink);
+}
+.theme-departure .alert-badge .alert-glyph {
+	color: var(--accent);
+}
+.theme-dark .alert-advisory {
+	border-left: 6px solid #d4b14a;
+	background: rgba(212, 177, 74, 0.08);
+}
+.theme-dark .alert-advisory .alert-glyph {
+	color: #d4b14a;
+}
+.theme-dark .alert-info {
+	border-left: 6px solid #9bb6d9;
+	background: rgba(155, 182, 217, 0.08);
+}
+.theme-dark .alert-info .alert-glyph {
+	color: #9bb6d9;
+}
+.theme-dark .alert-alert {
+	border-left: 6px solid #ff8b6a;
+	background: rgba(255, 139, 106, 0.08);
+}
+.theme-dark .alert-alert .alert-glyph {
+	color: #ff8b6a;
+}
+.theme-light .alert-advisory,
+.theme-light .alert-info {
+	border-left: 6px solid #0a0a0a;
+	background: #ffffff;
+}
+.theme-light .alert-alert {
+	border-left: 6px solid #0a0a0a;
+	background: #ffffff;
+	box-shadow:
+		inset 4px 0 0 #0a0a0a,
+		0 0 0 1px #0a0a0a;
+}
+.theme-light .alert-badge .alert-glyph {
+	color: #0a0a0a;
+}
+
+.theme-dark .route-badge {
+	background: linear-gradient(180deg, #1a1d24 0%, #1a1d24 49%, #14171c 51%, #14171c 100%);
+	border: 1px solid var(--rule-strong);
+	box-shadow:
+		inset 0 1px 0 rgba(255, 255, 255, 0.04),
+		inset 0 -1px 0 rgba(0, 0, 0, 0.4),
+		0 2px 0 rgba(0, 0, 0, 0.5);
+	--badge-ink: #d4b14a;
+	--badge-meta: rgba(244, 236, 216, 0.4);
+}
+.theme-light .route-badge {
+	background: #0a0a0a;
+	border: 1px solid #0a0a0a;
+	box-shadow: 0 2px 0 rgba(0, 0, 0, 0.06);
+	--badge-ink: #f5f3ee;
+	--badge-meta: rgba(245, 243, 238, 0.55);
+}
+
+@keyframes board-live-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.45;
+	}
+}

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,12 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			rel="stylesheet"
+			href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700;800&family=IBM+Plex+Sans+Condensed:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap"
+		/>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/components/board/alert-badge.svelte
+++ b/src/components/board/alert-badge.svelte
@@ -1,0 +1,54 @@
+<script>
+	import { formatTimestamp } from '$lib/formatters.js';
+
+	let { situation } = $props();
+
+	const headline = $derived(situation?.summary?.value?.trim?.() ?? '');
+	const activeWindow = $derived(situation?.activeWindows?.[0]);
+	const windowStart = $derived(activeWindow?.from ? formatTimestamp(activeWindow.from) : '');
+	const windowEnd = $derived(activeWindow?.to ? formatTimestamp(activeWindow.to) : '');
+	const severity = $derived(situation?.severity?.toLowerCase?.() ?? 'alert');
+</script>
+
+<div
+	class="alert-badge alert-{severity}"
+	style:width="760px"
+	style:padding="16px 24px"
+	style:border-radius="4px"
+	style:display="grid"
+	style:grid-template-columns="auto 1fr"
+	style:gap="20px"
+	style:align-items="center"
+>
+	<div
+		class="alert-glyph"
+		style:width="64px"
+		style:height="64px"
+		style:display="grid"
+		style:place-items="center"
+		style:border="2px solid currentColor"
+	>
+		<span style:font-size="36px" style:font-weight="800" style:line-height="1">!</span>
+	</div>
+	<div>
+		<div
+			class="sc"
+			style:font-size="14px"
+			style:letter-spacing="0.22em"
+			style:color="var(--ink-mute)"
+		>
+			SERVICE ADVISORY{#if windowStart}
+				· {windowStart}{#if windowEnd}
+					→ {windowEnd}{/if}{/if}
+		</div>
+		<div
+			style:font-size="22px"
+			style:font-weight="600"
+			style:line-height="1.25"
+			style:margin-top="4px"
+			style:color="var(--ink)"
+		>
+			{headline}
+		</div>
+	</div>
+</div>

--- a/src/components/board/arrival-hero.svelte
+++ b/src/components/board/arrival-hero.svelte
@@ -1,0 +1,98 @@
+<script>
+	import { formatTime } from '$lib/formatters.js';
+
+	let { arrival } = $props();
+
+	const isCancel = $derived(arrival.status === 'CANCEL');
+	const isSched = $derived(arrival.status === 'SCHED');
+	const showAsClock = $derived(isSched || arrival.min > 30);
+	const showNow = $derived(!isSched && arrival.min <= 0);
+	const clock = $derived(formatTime(arrival.departureAt));
+	const clockParts = $derived.by(() => {
+		const m = /(\d+:\d+)\s*(AM|PM)/i.exec(clock);
+		return m ? { hm: m[1], ap: m[2] } : { hm: clock, ap: '' };
+	});
+</script>
+
+{#if isCancel}
+	<div style:text-align="right">
+		<div
+			class="display sc"
+			style:font-size="80px"
+			style:font-weight="800"
+			style:line-height="0.9"
+			style:letter-spacing="0.04em"
+			style:color="var(--status-tone)"
+		>
+			—— ——
+		</div>
+		<div
+			class="sc"
+			style:font-size="18px"
+			style:letter-spacing="0.22em"
+			style:color="var(--ink-mute)"
+			style:margin-top="6px"
+		>
+			DO NOT BOARD
+		</div>
+	</div>
+{:else if showNow}
+	<div style:text-align="right">
+		<div
+			class="display sc"
+			style:font-size="130px"
+			style:font-weight="800"
+			style:line-height="0.9"
+			style:letter-spacing="0.04em"
+			style:color="var(--accent)"
+		>
+			NOW
+		</div>
+	</div>
+{:else if showAsClock}
+	<div style:text-align="right">
+		<div
+			class="display mono"
+			style:font-size="110px"
+			style:font-weight="600"
+			style:line-height="0.9"
+			style:letter-spacing="-0.02em"
+			style:color="var(--accent)"
+		>
+			{clockParts.hm}<span
+				style:font-size="56px"
+				style:margin-left="8px"
+				style:color="var(--ink-dim)">{clockParts.ap}</span
+			>
+		</div>
+	</div>
+{:else}
+	<div
+		style:text-align="right"
+		style:display="flex"
+		style:align-items="baseline"
+		style:justify-content="flex-end"
+		style:gap="14px"
+	>
+		<div
+			class="display mono"
+			style:font-size="156px"
+			style:font-weight="700"
+			style:line-height="0.9"
+			style:letter-spacing="-0.04em"
+			style:color="var(--accent)"
+			style:font-variant-numeric="tabular-nums"
+		>
+			{arrival.min}
+		</div>
+		<div
+			class="sc display"
+			style:font-size="36px"
+			style:font-weight="700"
+			style:letter-spacing="0.06em"
+			style:color="var(--ink-dim)"
+		>
+			MIN
+		</div>
+	</div>
+{/if}

--- a/src/components/board/board.svelte
+++ b/src/components/board/board.svelte
@@ -1,9 +1,10 @@
 <script>
-	import AlertBadge from './alert-badge.svelte';
-	import ClockBlock from './clock-block.svelte';
-	import DepartureRow from './departure-row.svelte';
-	import Legend from './legend.svelte';
-	import LiveDot from './live-dot.svelte';
+	import { getLocale } from '$lib/paraglide/runtime.js';
+	import AlertBadge from '$components/board/alert-badge.svelte';
+	import ClockBlock from '$components/board/clock-block.svelte';
+	import DepartureRow from '$components/board/departure-row.svelte';
+	import Legend from '$components/board/legend.svelte';
+	import LiveDot from '$components/board/live-dot.svelte';
 
 	const STALE_THRESHOLD_MS = 90_000;
 
@@ -201,13 +202,13 @@
 					{#if !updatedDate}
 						UPDATING…
 					{:else if stale}
-						STALE · LAST {updatedDate.toLocaleTimeString('en-US', {
+						STALE · LAST {updatedDate.toLocaleTimeString(getLocale(), {
 							hour: 'numeric',
 							minute: '2-digit',
 							second: '2-digit'
 						})}
 					{:else}
-						UPDATED {updatedDate.toLocaleTimeString('en-US', {
+						UPDATED {updatedDate.toLocaleTimeString(getLocale(), {
 							hour: 'numeric',
 							minute: '2-digit',
 							second: '2-digit'

--- a/src/components/board/board.svelte
+++ b/src/components/board/board.svelte
@@ -1,0 +1,220 @@
+<script>
+	import AlertBadge from './alert-badge.svelte';
+	import ClockBlock from './clock-block.svelte';
+	import DepartureRow from './departure-row.svelte';
+	import Legend from './legend.svelte';
+	import LiveDot from './live-dot.svelte';
+
+	const STALE_THRESHOLD_MS = 90_000;
+
+	let {
+		agencyName = '',
+		agencyLogo = '',
+		stopId = '',
+		stopName = '',
+		stopSubtitle = '',
+		arrivals = [],
+		alert = null,
+		now,
+		lastUpdatedAt = null,
+		isStale = false,
+		showStopName = false,
+		rowCount = 5,
+		showFooter = true,
+		showAlerts = true
+	} = $props();
+
+	const visible = $derived(arrivals.slice(0, rowCount));
+	const emptyCount = $derived(Math.max(0, rowCount - visible.length));
+	const hasAlert = $derived(showAlerts && !!alert);
+	const liveCount = $derived(arrivals.filter((a) => a.delta != null).length);
+	const updatedDate = $derived(lastUpdatedAt ? new Date(lastUpdatedAt) : null);
+	const ageMs = $derived(updatedDate ? now.getTime() - updatedDate.getTime() : null);
+	const stale = $derived(isStale || (ageMs != null && ageMs > STALE_THRESHOLD_MS));
+	const showLive = $derived(liveCount > 0 && !stale);
+</script>
+
+<div
+	style:position="absolute"
+	style:inset="0"
+	style:background="var(--bg)"
+	style:color="var(--ink)"
+	style:padding="28px 32px 24px"
+	style:display="grid"
+	style:grid-template-rows="118px auto 56px 1fr auto"
+	style:gap="16px"
+	style:z-index="1"
+>
+	<!-- HEADER -->
+	<header
+		style:display="grid"
+		style:grid-template-columns="auto 1fr auto"
+		style:align-items="center"
+		style:border-bottom="2px solid var(--rule-strong)"
+		style:padding-bottom="18px"
+	>
+		<div style:display="flex" style:align-items="center" style:gap="20px">
+			{#if agencyLogo}
+				<img
+					src={agencyLogo}
+					alt={agencyName}
+					style:height="64px"
+					style:width="auto"
+					style:object-fit="contain"
+				/>
+			{/if}
+			{#if agencyName}
+				<span
+					style:font-family="'IBM Plex Sans', sans-serif"
+					style:font-weight="700"
+					style:font-size="22px"
+					style:color="var(--ink)"
+					style:letter-spacing="0.01em"
+				>
+					{agencyName}
+				</span>
+			{/if}
+		</div>
+
+		<div style:display="flex" style:justify-content="center">
+			<div
+				class="sc display"
+				style:font-weight="800"
+				style:font-size="32px"
+				style:letter-spacing="0.24em"
+				style:color="var(--ink-dim)"
+			>
+				DEPARTURES
+			</div>
+		</div>
+
+		<ClockBlock {now} />
+	</header>
+
+	<!-- STOP IDENTITY -->
+	<section
+		style:display="grid"
+		style:grid-template-columns={hasAlert ? '1fr auto' : '1fr'}
+		style:align-items="end"
+		style:gap="24px"
+		style:padding-top="4px"
+	>
+		<div>
+			<div
+				class="sc"
+				style:font-size="18px"
+				style:letter-spacing="0.22em"
+				style:color="var(--ink-mute)"
+				style:margin-bottom="6px"
+			>
+				STOP #{stopId}
+			</div>
+			<div
+				class="display"
+				style:font-size="56px"
+				style:font-weight="700"
+				style:line-height="1"
+				style:letter-spacing="-0.01em"
+				style:white-space="nowrap"
+				style:overflow="hidden"
+				style:text-overflow="ellipsis"
+			>
+				{stopName}{#if stopSubtitle}<span style:color="var(--ink-dim)" style:font-weight="400">
+						· {stopSubtitle}</span
+					>{/if}
+			</div>
+		</div>
+
+		{#if hasAlert}
+			<AlertBadge situation={alert} />
+		{/if}
+	</section>
+
+	<!-- COLUMN HEADER -->
+	<div
+		class="sc tnum"
+		style:display="grid"
+		style:grid-template-columns="200px 1fr 380px 380px"
+		style:align-items="center"
+		style:gap="24px"
+		style:font-size="16px"
+		style:letter-spacing="0.22em"
+		style:color="var(--ink-mute)"
+		style:border-top="1px solid var(--rule)"
+		style:border-bottom="1px solid var(--rule)"
+		style:padding="14px 8px"
+	>
+		<div>ROUTE</div>
+		<div>DESTINATION</div>
+		<div style:text-align="right">ARRIVES</div>
+		<div style:text-align="right">STATUS</div>
+	</div>
+
+	<!-- ROWS -->
+	<div
+		style:display="grid"
+		style:grid-template-rows="repeat({rowCount}, 1fr)"
+		style:gap="6px"
+		style:min-height="0"
+	>
+		{#each visible as arrival (arrival.tripId ?? `${arrival.route}-${arrival.departureAt}`)}
+			<DepartureRow {arrival} {showStopName} />
+		{/each}
+		{#each Array.from({ length: emptyCount }, (_, i) => i) as i (i)}
+			<div style:border-bottom="1px dashed var(--rule)"></div>
+		{/each}
+	</div>
+
+	<!-- FOOTER -->
+	{#if showFooter}
+		<footer
+			style:display="grid"
+			style:grid-template-columns="auto 1fr auto"
+			style:align-items="center"
+			style:gap="32px"
+			style:border-top="1px solid var(--rule)"
+			style:padding-top="14px"
+			style:font-size="18px"
+		>
+			<div
+				class="sc"
+				style:font-size="15px"
+				style:letter-spacing="0.18em"
+				style:color="var(--ink-mute)"
+			>
+				<span style:color="var(--ink-dim)" style:font-weight="600">WAYSTATION</span>
+				<span style:margin="0 12px" style:color="var(--rule-strong)">/</span>
+				<span>Open Transit Software Foundation</span>
+			</div>
+
+			<Legend />
+
+			<div style:display="flex" style:align-items="center" style:gap="22px">
+				<LiveDot hasRealtime={showLive} />
+				<span
+					class="sc tnum"
+					style:font-size="15px"
+					style:letter-spacing="0.14em"
+					style:color={stale ? 'var(--late)' : 'var(--ink-mute)'}
+					style:font-weight={stale ? 700 : 400}
+				>
+					{#if !updatedDate}
+						UPDATING…
+					{:else if stale}
+						STALE · LAST {updatedDate.toLocaleTimeString('en-US', {
+							hour: 'numeric',
+							minute: '2-digit',
+							second: '2-digit'
+						})}
+					{:else}
+						UPDATED {updatedDate.toLocaleTimeString('en-US', {
+							hour: 'numeric',
+							minute: '2-digit',
+							second: '2-digit'
+						})}
+					{/if}
+				</span>
+			</div>
+		</footer>
+	{/if}
+</div>

--- a/src/components/board/clock-block.svelte
+++ b/src/components/board/clock-block.svelte
@@ -1,0 +1,39 @@
+<script>
+	import { formatDate } from '$lib/formatters.js';
+
+	let { now } = $props();
+
+	const dateText = $derived(formatDate(now));
+	const timeText = $derived(
+		now.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+	);
+	const seconds = $derived(now.getSeconds().toString().padStart(2, '0'));
+</script>
+
+<div style:text-align="right">
+	<div
+		class="sc"
+		style:font-size="18px"
+		style:letter-spacing="0.22em"
+		style:color="var(--ink-mute)"
+		style:margin-bottom="4px"
+	>
+		{dateText}
+	</div>
+	<div
+		class="mono display"
+		style:font-size="52px"
+		style:font-weight="600"
+		style:line-height="1"
+		style:letter-spacing="-0.02em"
+		style:color="var(--accent)"
+		style:white-space="nowrap"
+	>
+		{timeText}<span
+			style:color="var(--ink-dim)"
+			style:font-weight="400"
+			style:font-size="32px"
+			style:margin-left="6px">:{seconds}</span
+		>
+	</div>
+</div>

--- a/src/components/board/clock-block.svelte
+++ b/src/components/board/clock-block.svelte
@@ -1,11 +1,12 @@
 <script>
 	import { formatDate } from '$lib/formatters.js';
+	import { getLocale } from '$lib/paraglide/runtime.js';
 
 	let { now } = $props();
 
 	const dateText = $derived(formatDate(now));
 	const timeText = $derived(
-		now.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+		now.toLocaleTimeString(getLocale(), { hour: 'numeric', minute: '2-digit', hour12: true })
 	);
 	const seconds = $derived(now.getSeconds().toString().padStart(2, '0'));
 </script>

--- a/src/components/board/departure-row.svelte
+++ b/src/components/board/departure-row.svelte
@@ -1,8 +1,8 @@
 <script>
 	import { formatTime } from '$lib/formatters.js';
-	import ArrivalHero from './arrival-hero.svelte';
-	import RouteBadge from './route-badge.svelte';
-	import StatusPip from './status-pip.svelte';
+	import ArrivalHero from '$components/board/arrival-hero.svelte';
+	import RouteBadge from '$components/board/route-badge.svelte';
+	import StatusPip from '$components/board/status-pip.svelte';
 
 	let { arrival, showStopName = false } = $props();
 

--- a/src/components/board/departure-row.svelte
+++ b/src/components/board/departure-row.svelte
@@ -1,0 +1,86 @@
+<script>
+	import { formatTime } from '$lib/formatters.js';
+	import ArrivalHero from './arrival-hero.svelte';
+	import RouteBadge from './route-badge.svelte';
+	import StatusPip from './status-pip.svelte';
+
+	let { arrival, showStopName = false } = $props();
+
+	const isCancel = $derived(arrival.status === 'CANCEL');
+	const isSched = $derived(arrival.status === 'SCHED');
+	const clock = $derived(formatTime(arrival.departureAt));
+</script>
+
+<div
+	class="row status-{arrival.status}"
+	style:display="grid"
+	style:grid-template-columns="200px 1fr 380px 380px"
+	style:align-items="center"
+	style:gap="24px"
+	style:padding="0 8px"
+	style:border-bottom="1px solid var(--rule)"
+	style:position="relative"
+	style:opacity={isCancel ? 0.78 : 1}
+>
+	<RouteBadge route={arrival.route} />
+
+	<div style:min-width="0">
+		<div
+			class="display"
+			style:font-size="48px"
+			style:font-weight="700"
+			style:line-height="1.05"
+			style:letter-spacing="-0.01em"
+			style:white-space="nowrap"
+			style:overflow="hidden"
+			style:text-overflow="ellipsis"
+		>
+			{arrival.name}
+		</div>
+		<div
+			style:font-size="26px"
+			style:line-height="1.15"
+			style:color="var(--ink-dim)"
+			style:margin-top="6px"
+			style:white-space="nowrap"
+			style:overflow="hidden"
+			style:text-overflow="ellipsis"
+		>
+			<span
+				class="sc"
+				style:font-size="18px"
+				style:letter-spacing="0.16em"
+				style:color="var(--ink-mute)"
+				style:margin-right="10px">TO</span
+			>
+			{arrival.dest}{#if showStopName && arrival.stopName}<span
+					class="sc"
+					style:font-size="16px"
+					style:letter-spacing="0.16em"
+					style:color="var(--ink-mute)"
+					style:margin-left="16px">FROM {arrival.stopName}</span
+				>{/if}
+		</div>
+	</div>
+
+	<ArrivalHero {arrival} />
+
+	<div style:text-align="right">
+		<StatusPip status={arrival.status} delta={arrival.delta} large />
+		<div
+			class="mono"
+			style:margin-top="6px"
+			style:font-size="22px"
+			style:color="var(--ink-mute)"
+			style:letter-spacing="0.04em"
+		>
+			{#if isCancel}
+				<span class="canceled-time">{clock}</span>
+			{:else if isSched}
+				TIMETABLE
+			{:else}
+				SCHED {clock}
+			{/if}
+		</div>
+	</div>
+</div>

--- a/src/components/board/legend.svelte
+++ b/src/components/board/legend.svelte
@@ -1,0 +1,26 @@
+<script>
+	const items = [
+		{ glyph: '●', label: 'ON TIME' },
+		{ glyph: '▲', label: 'EARLY' },
+		{ glyph: '▼', label: 'DELAYED' },
+		{ glyph: '○', label: 'SCHEDULED' },
+		{ glyph: '✕', label: 'CANCELED' }
+	];
+</script>
+
+<div style:display="flex" style:justify-content="center" style:gap="36px">
+	{#each items as item (item.label)}
+		<span
+			class="sc tnum"
+			style:display="inline-flex"
+			style:gap="8px"
+			style:align-items="center"
+			style:font-size="14px"
+			style:letter-spacing="0.18em"
+			style:color="var(--ink-mute)"
+		>
+			<span style:font-size="16px" style:color="var(--ink-dim)">{item.glyph}</span>
+			<span>{item.label}</span>
+		</span>
+	{/each}
+</div>

--- a/src/components/board/live-dot.svelte
+++ b/src/components/board/live-dot.svelte
@@ -1,0 +1,26 @@
+<script>
+	let { hasRealtime = false } = $props();
+</script>
+
+<span
+	class="sc tnum"
+	style:display="inline-flex"
+	style:align-items="center"
+	style:gap="8px"
+	style:font-family="'IBM Plex Sans', sans-serif"
+	style:font-weight="600"
+	style:font-size="15px"
+	style:letter-spacing="0.12em"
+	style:color="var(--ink-dim)"
+>
+	<span
+		style:width="10px"
+		style:height="10px"
+		style:border-radius="50%"
+		style:background={hasRealtime ? 'var(--ontime)' : 'transparent'}
+		style:outline={hasRealtime ? 'none' : '2px solid currentColor'}
+		style:outline-offset="-2px"
+		style:animation={hasRealtime ? 'board-live-pulse 2s ease-in-out infinite' : 'none'}
+	></span>
+	<span>{hasRealtime ? 'LIVE' : 'SCHED'}</span>
+</span>

--- a/src/components/board/route-badge.svelte
+++ b/src/components/board/route-badge.svelte
@@ -1,6 +1,7 @@
 <script>
 	let { route } = $props();
-	const size = $derived(route.length <= 1 ? 96 : route.length === 2 ? 80 : 60);
+	const len = $derived(route?.length ?? 0);
+	const size = $derived(len <= 1 ? 96 : len === 2 ? 80 : 60);
 </script>
 
 <div

--- a/src/components/board/route-badge.svelte
+++ b/src/components/board/route-badge.svelte
@@ -1,0 +1,25 @@
+<script>
+	let { route } = $props();
+	const size = $derived(route.length <= 1 ? 96 : route.length === 2 ? 80 : 60);
+</script>
+
+<div
+	class="route-badge"
+	style:width="156px"
+	style:height="110px"
+	style:border-radius="14px"
+	style:display="grid"
+	style:place-items="center"
+	style:position="relative"
+>
+	<div
+		class="display tnum"
+		style:font-size="{size}px"
+		style:font-weight="800"
+		style:line-height="1"
+		style:color="var(--badge-ink)"
+		style:letter-spacing="-0.02em"
+	>
+		{route}
+	</div>
+</div>

--- a/src/components/board/status-pip.svelte
+++ b/src/components/board/status-pip.svelte
@@ -1,0 +1,36 @@
+<script>
+	const STATUS = {
+		ONTIME: { glyph: '●', label: 'ON TIME', weight: 500 },
+		EARLY: { glyph: '▲', label: 'EARLY', weight: 700 },
+		LATE: { glyph: '▼', label: 'DELAYED', weight: 700 },
+		CANCEL: { glyph: '✕', label: 'CANCELED', weight: 700 },
+		SCHED: { glyph: '○', label: 'SCHEDULED', weight: 500 }
+	};
+
+	let { status, delta = null, large = false } = $props();
+
+	const s = $derived(STATUS[status]);
+	const size = $derived(large ? 28 : 22);
+	const label = $derived.by(() => {
+		if (!s) return '';
+		if (status === 'EARLY' && delta != null) return `${Math.abs(delta)} MIN EARLY`;
+		if (status === 'LATE' && delta != null) return `${delta} MIN LATE`;
+		return s.label;
+	});
+</script>
+
+{#if s}
+	<span
+		class="status-{status} sc tnum"
+		style:display="inline-flex"
+		style:align-items="center"
+		style:gap="10px"
+		style:font-weight={s.weight}
+		style:font-size="{size}px"
+		style:color="var(--status-tone)"
+		style:letter-spacing="0.1em"
+	>
+		<span aria-hidden="true" style:font-size="{size * 0.95}px">{s.glyph}</span>
+		<span>{label}</span>
+	</span>
+{/if}

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -333,6 +333,43 @@ export function removeDuplicates(departures) {
 }
 
 /**
+ * Map an OBA arrival/departure into the Board UI's row model.
+ *
+ * @param {Object} dep - OBA arrivalAndDeparture record (with stopName already attached)
+ * @param {Date} [now=new Date()]
+ * @returns {{route: string, name: string, dest: string, min: number, delta: number|null, status: 'ONTIME'|'EARLY'|'LATE'|'SCHED'|'CANCEL', stopName: string, departureAt: number, tripId: string|undefined}}
+ */
+export function formatBoardDeparture(dep, now = new Date()) {
+	const predicted = dep.predictedDepartureTime;
+	const scheduled = dep.scheduledDepartureTime;
+	const departureAt = predicted && predicted > 0 ? predicted : scheduled;
+	const min = Math.floor((departureAt - now.getTime()) / 60000);
+
+	let delta = null;
+	let status = 'SCHED';
+	if (dep.tripStatus?.status === 'CANCELED') {
+		status = 'CANCEL';
+	} else if (predicted && predicted > 0) {
+		delta = Math.round((predicted - scheduled) / 60000);
+		if (delta <= -1) status = 'EARLY';
+		else if (delta >= 1) status = 'LATE';
+		else status = 'ONTIME';
+	}
+
+	return {
+		route: dep.routeShortName || '?',
+		name: dep.routeLongName || dep.tripHeadsign || '',
+		dest: dep.tripHeadsign || '',
+		min,
+		delta,
+		status,
+		stopName: dep.stopName ?? '',
+		departureAt,
+		tripId: dep.tripId
+	};
+}
+
+/**
  * Translates a given text into the specified target language by proxying
  * through Google’s unofficial translate endpoint.
  *

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -343,7 +343,8 @@ export function formatBoardDeparture(dep, now = new Date()) {
 	const predicted = dep.predictedDepartureTime;
 	const scheduled = dep.scheduledDepartureTime;
 	const departureAt = predicted && predicted > 0 ? predicted : scheduled;
-	const min = Math.floor((departureAt - now.getTime()) / 60000);
+	const hasValidTime = Number.isFinite(departureAt) && departureAt > 0;
+	const min = hasValidTime ? Math.floor((departureAt - now.getTime()) / 60000) : -Infinity;
 
 	let delta = null;
 	let status = 'SCHED';

--- a/src/lib/formatters.test.js
+++ b/src/lib/formatters.test.js
@@ -15,7 +15,8 @@ import {
 	formatTextColor,
 	generateRandomID,
 	sortEarliestDepartures,
-	removeDuplicates
+	removeDuplicates,
+	formatBoardDeparture
 } from '$lib/formatters';
 
 afterEach(() => {
@@ -106,6 +107,96 @@ describe('formatters', () => {
 			];
 			const filtered = removeDuplicates(deps);
 			expect(filtered.length).toBe(2);
+		});
+	});
+
+	describe('formatBoardDeparture', () => {
+		const NOW = new Date('2026-05-26T17:00:00');
+		const baseDep = {
+			routeShortName: '30',
+			routeLongName: 'Old Town – UTC',
+			tripHeadsign: 'UTC',
+			tripId: 'MTS_abc',
+			scheduledDepartureTime: NOW.getTime() + 5 * 60_000
+		};
+
+		test('marks CANCEL when tripStatus.status is CANCELED, regardless of predicted time', () => {
+			const dep = {
+				...baseDep,
+				predictedDepartureTime: NOW.getTime() + 5 * 60_000,
+				tripStatus: { status: 'CANCELED' }
+			};
+			const a = formatBoardDeparture(dep, NOW);
+			expect(a.status).toBe('CANCEL');
+			expect(a.delta).toBeNull();
+		});
+
+		test('returns SCHED when predicted is 0 (no realtime data)', () => {
+			const dep = { ...baseDep, predictedDepartureTime: 0 };
+			const a = formatBoardDeparture(dep, NOW);
+			expect(a.status).toBe('SCHED');
+			expect(a.delta).toBeNull();
+			expect(a.departureAt).toBe(baseDep.scheduledDepartureTime);
+		});
+
+		test('returns SCHED when predicted is undefined', () => {
+			const dep = { ...baseDep };
+			const a = formatBoardDeparture(dep, NOW);
+			expect(a.status).toBe('SCHED');
+		});
+
+		test('marks EARLY at the delta=-1 boundary', () => {
+			const dep = {
+				...baseDep,
+				predictedDepartureTime: baseDep.scheduledDepartureTime - 60_000
+			};
+			const a = formatBoardDeparture(dep, NOW);
+			expect(a.status).toBe('EARLY');
+			expect(a.delta).toBe(-1);
+		});
+
+		test('marks LATE at the delta=1 boundary', () => {
+			const dep = {
+				...baseDep,
+				predictedDepartureTime: baseDep.scheduledDepartureTime + 60_000
+			};
+			const a = formatBoardDeparture(dep, NOW);
+			expect(a.status).toBe('LATE');
+			expect(a.delta).toBe(1);
+		});
+
+		test('marks ONTIME when delta rounds to 0', () => {
+			const dep = {
+				...baseDep,
+				predictedDepartureTime: baseDep.scheduledDepartureTime + 20_000
+			};
+			const a = formatBoardDeparture(dep, NOW);
+			expect(a.status).toBe('ONTIME');
+			expect(a.delta).toBe(0);
+		});
+
+		test('min uses Math.floor for departures in the past', () => {
+			const dep = {
+				...baseDep,
+				scheduledDepartureTime: NOW.getTime() - 90_000,
+				predictedDepartureTime: NOW.getTime() - 90_000
+			};
+			const a = formatBoardDeparture(dep, NOW);
+			expect(a.min).toBe(-2);
+		});
+
+		test('falls back to ? for missing route and to tripHeadsign for missing routeLongName', () => {
+			const dep = { tripHeadsign: 'Downtown', scheduledDepartureTime: NOW.getTime() + 60_000 };
+			const a = formatBoardDeparture(dep, NOW);
+			expect(a.route).toBe('?');
+			expect(a.name).toBe('Downtown');
+			expect(a.dest).toBe('Downtown');
+		});
+
+		test('falls back to ? for empty routeShortName', () => {
+			const dep = { ...baseDep, routeShortName: '' };
+			const a = formatBoardDeparture(dep, NOW).route;
+			expect(a).toBe('?');
 		});
 	});
 });

--- a/src/lib/formatters.test.js
+++ b/src/lib/formatters.test.js
@@ -198,5 +198,12 @@ describe('formatters', () => {
 			const a = formatBoardDeparture(dep, NOW).route;
 			expect(a).toBe('?');
 		});
+
+		test('produces a finite min (not NaN) when both timestamps are missing', () => {
+			const dep = { routeShortName: '99', tripHeadsign: 'Nowhere' };
+			const a = formatBoardDeparture(dep, NOW);
+			expect(Number.isNaN(a.min)).toBe(false);
+			expect(a.min).toBeLessThan(-2);
+		});
 	});
 });

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -117,7 +117,8 @@
 			if (!res.ok) throw new Error(`/api/config returned ${res.status}`);
 			const config = await res.json();
 			refreshIntervalMs = (Number(config.updateInterval) || 30) * 1000;
-			maxDepartures = Number(config.maxDepartures) || 5;
+			const parsedMax = Math.floor(Number(config.maxDepartures));
+			maxDepartures = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : 5;
 		} catch (err) {
 			console.error('Config fetch failed; using defaults (30s refresh, 5 departures):', err);
 		}

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -1,23 +1,166 @@
 <script>
 	import { PUBLIC_OBA_LOGO_URL, PUBLIC_OBA_REGION_NAME } from '$env/static/public';
+	import { browser } from '$app/environment';
+	import { onDestroy, onMount } from 'svelte';
 
-	import Header from '$components/navigation/header.svelte';
-	import Controller from '$components/controller/controller.svelte';
-	import Footer from '$components/navigation/footer.svelte';
+	import Board from '$components/board/board.svelte';
+	import {
+		formatBoardDeparture,
+		removeDuplicates,
+		sortEarliestDepartures
+	} from '$lib/formatters.js';
 
 	let { data } = $props();
+
+	const theme = 'dark';
+	const showStopName = data.stopIDs.length > 1;
+	const ALERT_ROTATE_MS = 8000;
+
+	let now = $state(new Date());
+	let arrivals = $state([]);
+	let situations = $state([]);
+	let alertIndex = $state(0);
+	let stopId = $state('');
+	let stopName = $state('');
+	let lastUpdatedAt = $state(null);
+	let isStale = $state(false);
+
+	const activeAlert = $derived(
+		situations.length > 0 ? situations[alertIndex % situations.length] : null
+	);
+
+	let clockTimer;
+	let fetchTimer;
+	let alertTimer;
+	let cancelled = false;
+	let fetchInFlight = false;
+	let refreshIntervalMs = 30_000;
+	let maxDepartures = $state(5);
+
+	async function fetchStop(id) {
+		const response = await fetch(`/api/oba/arrivals-and-departures-for-stop/${id}`);
+		if (!response.ok) throw new Error(`HTTP ${response.status} for stop ${id}`);
+		const json = await response.json();
+
+		if (!json?.data?.references?.stops || !json?.data?.entry?.arrivalsAndDepartures) {
+			throw new Error(`malformed response for stop ${id}`);
+		}
+
+		const stopRecord = Object.values(json.data.references.stops).find((s) => s.id === id);
+		const resolvedName = stopRecord?.name ?? `Stop #${id.split('_')[1] ?? id}`;
+
+		return {
+			stopId: id,
+			stopName: resolvedName,
+			stale: json.stale === true,
+			departures: json.data.entry.arrivalsAndDepartures.map((dep) => ({
+				...dep,
+				stopName: resolvedName
+			})),
+			situations: json.data.references.situations ?? []
+		};
+	}
+
+	async function fetchAll() {
+		if (fetchInFlight) return;
+		fetchInFlight = true;
+		try {
+			const ids = data.stopIDs;
+			const settled = await Promise.allSettled(ids.map(fetchStop));
+			const fulfilled = [];
+			settled.forEach((r, i) => {
+				if (r.status === 'fulfilled') fulfilled.push(r.value);
+				else console.error(`Board fetch failed for stop ${ids[i]}:`, r.reason);
+			});
+
+			if (fulfilled.length === 0) return;
+
+			const fetchNow = new Date();
+			const all = fulfilled.flatMap((r) => r.departures);
+			const mapped = sortEarliestDepartures(removeDuplicates(all))
+				.map((dep) => formatBoardDeparture(dep, fetchNow))
+				.filter((a) => a.min >= -2);
+
+			arrivals = mapped;
+			situations = fulfilled.flatMap((r) => r.situations).filter((s) => s?.summary?.value);
+			isStale = fulfilled.some((r) => r.stale);
+
+			const primary = fulfilled[0];
+			stopId = primary.stopId.split('_')[1] ?? primary.stopId;
+			stopName = primary.stopName;
+			lastUpdatedAt = fetchNow.getTime();
+		} finally {
+			fetchInFlight = false;
+		}
+	}
+
+	function fitStage() {
+		const stage = document.getElementById('board-stage');
+		if (!stage) return;
+		const w = window.innerWidth;
+		const h = window.innerHeight;
+		const scale = Math.min(w / 1920, h / 1080);
+		const tx = (w - 1920 * scale) / 2;
+		const ty = (h - 1080 * scale) / 2;
+		stage.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
+	}
+
+	function safeTick() {
+		fetchAll().catch((err) => console.error('fetchAll tick failed:', err));
+	}
+
+	onMount(async () => {
+		document.body.classList.add('board-body');
+
+		try {
+			const res = await fetch('/api/config');
+			if (!res.ok) throw new Error(`/api/config returned ${res.status}`);
+			const config = await res.json();
+			refreshIntervalMs = (Number(config.updateInterval) || 30) * 1000;
+			maxDepartures = Number(config.maxDepartures) || 5;
+		} catch (err) {
+			console.error('Config fetch failed; using defaults (30s refresh, 5 departures):', err);
+		}
+
+		await fetchAll().catch((err) => console.error('Initial fetchAll failed:', err));
+
+		if (cancelled) return;
+
+		fitStage();
+		window.addEventListener('resize', fitStage);
+		clockTimer = setInterval(() => (now = new Date()), 1000);
+		fetchTimer = setInterval(safeTick, refreshIntervalMs);
+		alertTimer = setInterval(() => {
+			if (situations.length > 0) alertIndex = (alertIndex + 1) % situations.length;
+		}, ALERT_ROTATE_MS);
+	});
+
+	onDestroy(() => {
+		cancelled = true;
+		if (browser) {
+			document.body.classList.remove('board-body');
+			window.removeEventListener('resize', fitStage);
+		}
+		clearInterval(clockTimer);
+		clearInterval(fetchTimer);
+		clearInterval(alertTimer);
+	});
 </script>
 
-<div class="flex h-screen flex-col">
-	<Header title={PUBLIC_OBA_REGION_NAME} imageUrl={PUBLIC_OBA_LOGO_URL} />
-
-	<div class="flex flex-1 gap-4 overflow-hidden">
-		<div class="flex-1 overflow-y-auto">
-			<Controller stopIDs={data.stopIDs} />
-		</div>
-	</div>
-
-	<div id="footer">
-		<Footer stopIDs={data.stopIDs} class="shrink-0" />
+<div class="board-stage-wrap">
+	<div id="board-stage" class="board-stage theme-departure theme-{theme}">
+		<Board
+			agencyName={PUBLIC_OBA_REGION_NAME}
+			agencyLogo={PUBLIC_OBA_LOGO_URL}
+			{stopId}
+			{stopName}
+			{arrivals}
+			alert={activeAlert}
+			{now}
+			{lastUpdatedAt}
+			{isStale}
+			{showStopName}
+			rowCount={Math.min(maxDepartures, 5)}
+		/>
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- Replace the vertical departure list on `/stops/[stopID]` with a 1920×1080 kiosk-scaled Solari-style board (warm cream + amber on near-black) per the Claude Design *Waystation* handoff. The stage scales to any viewport via a JS-computed CSS transform.
- New `formatBoardDeparture()` maps OBA arrivals to the row model with `ONTIME / EARLY / LATE / SCHED / CANCEL` (wired from `tripStatus.status`), plus 9 new unit tests covering the boundary cases.
- New page handles polling inline: `Promise.allSettled` so one bad stop doesn't blank the board, an in-flight guard so slow fetches don't race, an unmount-cancellation flag, and a stale-data signal (`STALE · LAST hh:mm:ss` in red) when the proxy returns cached data or no fetch lands within 90s.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run check` clean
- [x] `npm test` — 44/44 passing (added 9 for `formatBoardDeparture`)
- [x] Live verified at 1920×1080 with real OBA data (MTS_10003): two Route 30 departures with `1 MIN LATE` / `4 MIN LATE` pips, absolute `SCHED 8:02 PM` timestamps (no drift between fetches), service-advisory badge wrapping correctly, `LIVE` + `UPDATED 7:59:12 PM` distinct from the wall clock
- [x] Off-aspect viewport (1800×900) verified — stage centers with letterboxing
- [x] Light theme briefly verified — pure ink-on-paper for e-ink

## Review notes / known gaps (deferred)
These came out of the review pass and are intentionally out-of-scope for this PR:

- **i18n regression:** all board labels (`DEPARTURES`, `ROUTE`, `STATUS`, `SCHED`, `UPDATED`, `SERVICE ADVISORY`, etc.) are hardcoded English. The previous controller used Paraglide messages and dynamically Google-translated alerts. Localizing the new layout is a separate change.
- **`vw` vs `px` sizing convention:** `CLAUDE.md` documents `vw` units, but the kiosk uses fixed `px` inside a transform-scaled stage. Worth documenting both conventions in `CLAUDE.md`.
- **Partial multi-stop failure UI:** when one of N stops fails, the board renders the surviving stops' rows but doesn't visibly say "stop X unavailable". Needs a design call.
- **First-load empty state:** if every stop's first fetch fails, the footer reads `UPDATING…` indefinitely. Needs a design for the no-data panel.
- **Dead `Controller` / `Footer` components:** the new page bypasses `src/components/controller/controller.svelte` and `src/components/navigation/footer.svelte`. Their tests still pass since the components are unchanged, but nothing in production hits them. Cleanup PR.
- **Body-class hack vs `+layout.svelte`:** the page toggles `body.board-body` to escape the global background. Works correctly; a per-route `+layout.svelte` would be cleaner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a departure board display for transit stops featuring real-time arrival and departure information
  * Implemented light and dark theme support with transit station-inspired visual design
  * Added live status indicators showing on-time, early, delayed, and canceled departures
  * Integrated service alerts and advisories display
  * Added responsive board layout with live data refresh indicators

* **Tests**
  * Added unit tests for departure data formatting logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OneBusAway/waystation/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->