### PR TITLE
fix: show scheduled-only departures on the board

### DIFF
--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -284,15 +284,17 @@ export function generateRandomID(tripID, stopID) {
  * @returns {Array} - Sorted array of valid departures in chronological order
  */
 export function sortEarliestDepartures(departures) {
+	// OBA returns predictedDepartureTime: 0 when no real-time prediction exists, so we use
+	// `||` (not `??`) to fall through to scheduledDepartureTime for scheduled-only departures.
 	const validDepartures = departures.filter((dep) => {
-		const time = dep.predictedDepartureTime ?? dep.scheduledDepartureTime;
+		const time = dep.predictedDepartureTime || dep.scheduledDepartureTime;
 
 		return time && time > 0;
 	});
 
 	const sortedDepartures = validDepartures.sort((x, y) => {
-		const timeX = x.predictedDepartureTime ?? x.scheduledDepartureTime;
-		const timeY = y.predictedDepartureTime ?? y.scheduledDepartureTime;
+		const timeX = x.predictedDepartureTime || x.scheduledDepartureTime;
+		const timeY = y.predictedDepartureTime || y.scheduledDepartureTime;
 
 		return timeX - timeY;
 	});

--- a/src/lib/formatters.test.js
+++ b/src/lib/formatters.test.js
@@ -99,6 +99,18 @@ describe('formatters', () => {
 			expect(sorted[0].scheduledDepartureTime).toBe(1000);
 		});
 
+		test('sortEarliestDepartures keeps scheduled-only departures (predictedDepartureTime === 0)', () => {
+			const deps = [
+				{ predictedDepartureTime: 0, scheduledDepartureTime: 3000 },
+				{ predictedDepartureTime: 0, scheduledDepartureTime: 1000 },
+				{ predictedDepartureTime: 0, scheduledDepartureTime: 2000 }
+			];
+			const sorted = sortEarliestDepartures(deps);
+			expect(sorted.length).toBe(3);
+			expect(sorted[0].scheduledDepartureTime).toBe(1000);
+			expect(sorted[2].scheduledDepartureTime).toBe(3000);
+		});
+
 		test('removeDuplicates filters duplicates correctly', () => {
 			const deps = [
 				{ tripId: '1', scheduledDepartureTime: 1000 },


### PR DESCRIPTION
## Summary
- `sortEarliestDepartures` used `??` to fall back from `predictedDepartureTime` to `scheduledDepartureTime`, but OBA returns `predictedDepartureTime: 0` (not `null`) when no real-time prediction exists. `??` treats `0` as a real value, so the subsequent `time > 0` check dropped every scheduled-only departure. Switch to `||` so the `0` sentinel falls through.
- This surfaced on the new Solari board (#72) because it sorts before formatting; the old controller path masked the bug via `formatArrivalStatus`'s explicit `predictedTime === 0` branch.
- Repro: stop `MTS_2055` (UCSD Triton Transit IL — Inside Loop) currently has only scheduled departures and rendered empty on production; iOS app showed three.

## Test plan
- [x] Added regression test `sortEarliestDepartures keeps scheduled-only departures (predictedDepartureTime === 0)` — fails on old code, passes on new.
- [x] Full vitest suite green (46 tests).
- [x] Manually verified `/stops/MTS_2055` against the live SD OBA API in a local dev server — board now shows IL Inside Loop at 8:37 / 8:52 / 9:07 PM, all marked SCHEDULED, matching the iOS app.
- [x] Manually verified `/stops/MTS_11380` (real-time stop) still renders correctly with LIVE indicator and ON TIME status — no regression in the realtime path.