### PR TITLE
Add empty-state experience for the departure board

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -220,3 +220,41 @@ body.board-body::before {
 		opacity: 0.45;
 	}
 }
+
+@keyframes board-empty-sweep {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+@keyframes board-empty-rise {
+	from {
+		opacity: 0;
+		transform: translateY(14px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.board-empty-rise {
+	animation: board-empty-rise 0.6s ease both;
+}
+
+.board-empty-sweep {
+	transform-origin: 100px 100px;
+	animation: board-empty-sweep 8s linear infinite;
+}
+
+.board-empty-pulse {
+	animation: board-live-pulse 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.board-empty-sweep,
+	.board-empty-rise,
+	.board-empty-pulse {
+		animation: none !important;
+	}
+}

--- a/src/components/board/board.svelte
+++ b/src/components/board/board.svelte
@@ -3,6 +3,7 @@
 	import AlertBadge from '$components/board/alert-badge.svelte';
 	import ClockBlock from '$components/board/clock-block.svelte';
 	import DepartureRow from '$components/board/departure-row.svelte';
+	import EmptyBoard from '$components/board/empty-board.svelte';
 	import Legend from '$components/board/legend.svelte';
 	import LiveDot from '$components/board/live-dot.svelte';
 
@@ -33,6 +34,7 @@
 	const ageMs = $derived(updatedDate ? now.getTime() - updatedDate.getTime() : null);
 	const stale = $derived(isStale || (ageMs != null && ageMs > STALE_THRESHOLD_MS));
 	const showLive = $derived(liveCount > 0 && !stale);
+	const emptyMode = $derived(!updatedDate ? 'connecting' : stale ? 'stale' : 'empty');
 </script>
 
 <div
@@ -152,19 +154,23 @@
 	</div>
 
 	<!-- ROWS -->
-	<div
-		style:display="grid"
-		style:grid-template-rows="repeat({rowCount}, 1fr)"
-		style:gap="6px"
-		style:min-height="0"
-	>
-		{#each visible as arrival (arrival.tripId ?? `${arrival.route}-${arrival.departureAt}`)}
-			<DepartureRow {arrival} {showStopName} />
-		{/each}
-		{#each Array.from({ length: emptyCount }, (_, i) => i) as i (i)}
-			<div style:border-bottom="1px dashed var(--rule)"></div>
-		{/each}
-	</div>
+	{#if visible.length === 0}
+		<EmptyBoard mode={emptyMode} {rowCount} />
+	{:else}
+		<div
+			style:display="grid"
+			style:grid-template-rows="repeat({rowCount}, 1fr)"
+			style:gap="6px"
+			style:min-height="0"
+		>
+			{#each visible as arrival (arrival.tripId ?? `${arrival.route}-${arrival.departureAt}`)}
+				<DepartureRow {arrival} {showStopName} />
+			{/each}
+			{#each Array.from({ length: emptyCount }, (_, i) => i) as i (i)}
+				<div style:border-bottom="1px dashed var(--rule)"></div>
+			{/each}
+		</div>
+	{/if}
 
 	<!-- FOOTER -->
 	{#if showFooter}

--- a/src/components/board/board.test.js
+++ b/src/components/board/board.test.js
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { render, cleanup } from '@testing-library/svelte';
+import { describe, test, expect, afterEach } from 'vitest';
+import Board from './board.svelte';
+
+// When a stop has no departures, the board renders the EmptyBoard whose headline
+// is driven by `emptyMode = !updatedDate ? 'connecting' : stale ? 'stale' : 'empty'`.
+// These tests pin that branching — the ternary ordering is easy to invert, and a
+// regression would silently show a rider the wrong state (e.g. "CONNECTING" forever
+// when the live feed is actually stale).
+describe('Board empty state', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	const now = new Date('2026-06-11T15:55:00Z');
+
+	function renderEmpty(props) {
+		return render(Board, { props: { arrivals: [], now, ...props } });
+	}
+
+	test('shows CONNECTING before the first fetch resolves', () => {
+		const { container } = renderEmpty({ lastUpdatedAt: null });
+		expect(container.innerHTML).toContain('CONNECTING');
+	});
+
+	test('shows NO DEPARTURES once loaded with no service', () => {
+		const { container } = renderEmpty({ lastUpdatedAt: now.getTime(), isStale: false });
+		expect(container.innerHTML).toContain('NO DEPARTURES');
+	});
+
+	test('shows NO LIVE DATA when the upstream feed is flagged stale', () => {
+		const { container } = renderEmpty({ lastUpdatedAt: now.getTime(), isStale: true });
+		expect(container.innerHTML).toContain('NO LIVE DATA');
+	});
+
+	test('shows NO LIVE DATA when data ages past the 90s staleness threshold', () => {
+		const { container } = renderEmpty({ lastUpdatedAt: now.getTime() - 91_000, isStale: false });
+		expect(container.innerHTML).toContain('NO LIVE DATA');
+	});
+});

--- a/src/components/board/empty-board.svelte
+++ b/src/components/board/empty-board.svelte
@@ -1,0 +1,158 @@
+<script>
+	// `mode` is decided by the parent board; this component is a pure visual
+	// lookup with no state logic of its own. Each idle state gets its own copy +
+	// accent so a glance tells you whether we're starting up, genuinely quiet, or
+	// have lost the live feed.
+	const COPY = {
+		connecting: {
+			kicker: 'AWAITING SIGNAL',
+			head: 'CONNECTING',
+			sub: 'Retrieving real-time arrivals…',
+			chip: 'ESTABLISHING CONNECTION',
+			accent: 'var(--sched)'
+		},
+		empty: {
+			kicker: 'ALL CLEAR',
+			head: 'NO DEPARTURES',
+			sub: 'No scheduled service for this stop right now',
+			chip: 'MONITORING FOR UPDATES',
+			accent: 'var(--ontime)'
+		},
+		stale: {
+			kicker: 'SIGNAL INTERRUPTED',
+			head: 'NO LIVE DATA',
+			sub: 'Real-time feed unavailable — retrying',
+			chip: 'ATTEMPTING TO RECONNECT',
+			accent: 'var(--late)'
+		}
+	};
+
+	let { mode = 'connecting', rowCount = 5 } = $props();
+
+	const copy = $derived(COPY[mode] ?? COPY.connecting);
+
+	// 60 ticks (majors every 5) plus the single sweep arm below — but no
+	// hour/minute hands, so it reads as "waiting" rather than a real clock.
+	const ticks = Array.from({ length: 60 }, (_, i) => i);
+	const ghosts = Array.from({ length: rowCount }, (_, i) => i);
+</script>
+
+<div style:position="relative" style:min-height="0" style:height="100%">
+	<!-- Ghost rows keep the board's row rhythm so the screen never reads as broken -->
+	<div
+		style:position="absolute"
+		style:inset="0"
+		style:display="grid"
+		style:grid-template-rows="repeat({rowCount}, 1fr)"
+		style:gap="6px"
+		aria-hidden="true"
+	>
+		{#each ghosts as i (i)}
+			<div style:border-bottom="1px dashed var(--rule)" style:opacity="0.5"></div>
+		{/each}
+	</div>
+
+	<!-- Idle plate -->
+	<div style:position="absolute" style:inset="0" style:display="grid" style:place-items="center">
+		<div
+			role="status"
+			aria-live="polite"
+			style:display="flex"
+			style:flex-direction="column"
+			style:align-items="center"
+			style:text-align="center"
+			style:gap="6px"
+		>
+			<!-- Station-clock mark: no hour/minute hands, one slow sweeping arm -->
+			<svg
+				class="board-empty-rise"
+				width="128"
+				height="128"
+				viewBox="0 0 200 200"
+				fill="none"
+				aria-hidden="true"
+				style:margin-bottom="30px"
+			>
+				<circle cx="100" cy="100" r="92" stroke="var(--rule-strong)" stroke-width="2" />
+				{#each ticks as i (i)}
+					{@const major = i % 5 === 0}
+					<line
+						x1="100"
+						y1="12"
+						x2="100"
+						y2={major ? 24 : 18}
+						stroke={major ? 'var(--ink-mute)' : 'var(--rule)'}
+						stroke-width={major ? 3 : 1.5}
+						transform="rotate({i * 6} 100 100)"
+					/>
+				{/each}
+				<g class="board-empty-sweep">
+					<line
+						x1="100"
+						y1="100"
+						x2="100"
+						y2="30"
+						stroke={copy.accent}
+						stroke-width="3"
+						stroke-linecap="round"
+					/>
+					<circle cx="100" cy="30" r="4.5" fill={copy.accent} />
+				</g>
+				<circle cx="100" cy="100" r="6" fill="var(--ink-mute)" />
+			</svg>
+
+			<div
+				class="sc board-empty-rise"
+				style:font-size="18px"
+				style:letter-spacing="0.32em"
+				style:color={copy.accent}
+				style:animation-delay="0.08s"
+			>
+				{copy.kicker}
+			</div>
+
+			<div
+				class="display board-empty-rise"
+				style:font-size="72px"
+				style:font-weight="700"
+				style:line-height="1"
+				style:letter-spacing="-0.01em"
+				style:color="var(--ink)"
+				style:animation-delay="0.16s"
+			>
+				{copy.head}
+			</div>
+
+			<div
+				class="board-empty-rise"
+				style:font-size="26px"
+				style:color="var(--ink-dim)"
+				style:margin-top="2px"
+				style:animation-delay="0.24s"
+			>
+				{copy.sub}
+			</div>
+
+			<div
+				class="sc tnum board-empty-rise"
+				style:display="inline-flex"
+				style:align-items="center"
+				style:gap="12px"
+				style:margin-top="26px"
+				style:font-size="15px"
+				style:letter-spacing="0.18em"
+				style:color="var(--ink-mute)"
+				style:animation-delay="0.32s"
+			>
+				<span
+					class="board-empty-pulse"
+					style:width="10px"
+					style:height="10px"
+					style:border-radius="50%"
+					style:background={copy.accent}
+				></span>
+				<span>{copy.chip}</span>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -373,6 +373,35 @@ export function formatBoardDeparture(dep, now = new Date()) {
 }
 
 /**
+ * Normalize an OBA arrivals-and-departures-for-stop response into the board's
+ * per-stop result model.
+ *
+ * Upstream OBA returns the literal body `null` (HTTP 200) for some valid stops
+ * that have no available real-time data (e.g. MTS_75057). A response without a
+ * departures array is treated as an empty result rather than an error, so the
+ * board renders an empty state instead of failing.
+ *
+ * @param {Object|null} json - Parsed proxy response (may be null)
+ * @param {string} id - Stop ID (e.g. "MTS_75057")
+ * @returns {{stopId: string, stopName: string, stale: boolean, departures: Array, situations: Array}}
+ */
+export function parseStopDepartures(json, id) {
+	const stopsRef = json?.data?.references?.stops;
+	const stopRecord = stopsRef ? Object.values(stopsRef).find((s) => s.id === id) : null;
+	const stopName = stopRecord?.name ?? `Stop #${id.split('_')[1] ?? id}`;
+
+	const departures = json?.data?.entry?.arrivalsAndDepartures;
+
+	return {
+		stopId: id,
+		stopName,
+		stale: json?.stale === true,
+		departures: Array.isArray(departures) ? departures.map((dep) => ({ ...dep, stopName })) : [],
+		situations: json?.data?.references?.situations ?? []
+	};
+}
+
+/**
  * Translates a given text into the specified target language by proxying
  * through Google’s unofficial translate endpoint.
  *

--- a/src/lib/formatters.test.js
+++ b/src/lib/formatters.test.js
@@ -16,7 +16,8 @@ import {
 	generateRandomID,
 	sortEarliestDepartures,
 	removeDuplicates,
-	formatBoardDeparture
+	formatBoardDeparture,
+	parseStopDepartures
 } from '$lib/formatters';
 
 afterEach(() => {
@@ -216,6 +217,64 @@ describe('formatters', () => {
 			const a = formatBoardDeparture(dep, NOW);
 			expect(Number.isNaN(a.min)).toBe(false);
 			expect(a.min).toBeLessThan(-2);
+		});
+	});
+
+	describe('parseStopDepartures', () => {
+		const validResponse = {
+			data: {
+				references: {
+					stops: [{ id: 'MTS_75057', name: 'Stadium Station' }],
+					situations: [{ summary: { value: 'Detour' } }]
+				},
+				entry: {
+					arrivalsAndDepartures: [
+						{ tripId: 'MTS_1', routeShortName: '530' },
+						{ tripId: 'MTS_2', routeShortName: '530' }
+					]
+				}
+			}
+		};
+
+		test('returns an empty result without throwing when the response is null', () => {
+			// Upstream OBA returns the literal body `null` (HTTP 200) for some valid
+			// stops with no available real-time data, e.g. MTS_75057.
+			const result = parseStopDepartures(null, 'MTS_75057');
+			expect(result.stopId).toBe('MTS_75057');
+			expect(result.departures).toEqual([]);
+			expect(result.situations).toEqual([]);
+			expect(result.stale).toBe(false);
+		});
+
+		test('falls back to "Stop #<code>" for the name when references are absent', () => {
+			const result = parseStopDepartures(null, 'MTS_75057');
+			expect(result.stopName).toBe('Stop #75057');
+		});
+
+		test('resolves the stop name and attaches it to each departure', () => {
+			const result = parseStopDepartures(validResponse, 'MTS_75057');
+			expect(result.stopName).toBe('Stadium Station');
+			expect(result.departures).toHaveLength(2);
+			expect(result.departures[0].stopName).toBe('Stadium Station');
+			expect(result.departures[0].tripId).toBe('MTS_1');
+			expect(result.situations).toHaveLength(1);
+		});
+
+		test('returns an empty departures list (with resolved name) for a valid stop with no departures', () => {
+			const response = {
+				data: {
+					references: { stops: [{ id: 'MTS_75057', name: 'Stadium Station' }] },
+					entry: { arrivalsAndDepartures: [] }
+				}
+			};
+			const result = parseStopDepartures(response, 'MTS_75057');
+			expect(result.departures).toEqual([]);
+			expect(result.stopName).toBe('Stadium Station');
+		});
+
+		test('passes through the stale flag', () => {
+			const result = parseStopDepartures({ ...validResponse, stale: true }, 'MTS_75057');
+			expect(result.stale).toBe(true);
 		});
 	});
 });

--- a/src/routes/api/oba/arrivals-and-departures-for-stop/[id]/+server.js
+++ b/src/routes/api/oba/arrivals-and-departures-for-stop/[id]/+server.js
@@ -9,7 +9,11 @@ export async function GET({ params }) {
 	try {
 		const response = await oba.arrivalAndDeparture.list(stopID);
 
-		cache.set(stopID, response);
+		// Upstream returns `null` (HTTP 200) for some valid stops with no real-time
+		// data. Only cache responses with real data so we never serve null as stale.
+		if (response?.data?.entry?.arrivalsAndDepartures) {
+			cache.set(stopID, response);
+		}
 
 		return new Response(JSON.stringify(response), {
 			headers: { 'Content-Type': 'application/json' }

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -6,6 +6,7 @@
 	import Board from '$components/board/board.svelte';
 	import {
 		formatBoardDeparture,
+		parseStopDepartures,
 		removeDuplicates,
 		sortEarliestDepartures
 	} from '$lib/formatters.js';
@@ -42,23 +43,10 @@
 		if (!response.ok) throw new Error(`HTTP ${response.status} for stop ${id}`);
 		const json = await response.json();
 
-		if (!json?.data?.references?.stops || !json?.data?.entry?.arrivalsAndDepartures) {
-			throw new Error(`malformed response for stop ${id}`);
-		}
-
-		const stopRecord = Object.values(json.data.references.stops).find((s) => s.id === id);
-		const resolvedName = stopRecord?.name ?? `Stop #${id.split('_')[1] ?? id}`;
-
-		return {
-			stopId: id,
-			stopName: resolvedName,
-			stale: json.stale === true,
-			departures: json.data.entry.arrivalsAndDepartures.map((dep) => ({
-				...dep,
-				stopName: resolvedName
-			})),
-			situations: json.data.references.situations ?? []
-		};
+		// Upstream OBA returns `null` (HTTP 200) for some valid stops with no
+		// real-time data; parseStopDepartures normalizes that into an empty result
+		// rather than throwing, so the board shows an empty state instead of failing.
+		return parseStopDepartures(json, id);
 	}
 
 	async function fetchAll() {


### PR DESCRIPTION
## Summary
- When a stop has no departures, the board previously rendered a dead screen of blank dashed rows (see before/after). Add a dedicated `EmptyBoard` component that fills the rows region with a **station-clock idle plate** — a hands-less clock with a slow sweeping arm over the board's own ghost rows, so the screen reads as "waiting," not "broken."
- Distinguishes **three states**, each color-coded for a glance from across a platform: `connecting` (first load, blue), `no departures` (loaded + clear, green), and `signal lost` (stale feed, warm red — coordinates with the footer's existing STALE indicator).
- Reuses the board's type system (`.sc`/`.tnum`/`.display`, IBM Plex), color tokens, and the existing `board-live-pulse` animation; respects `prefers-reduced-motion` (all idle animations stop).
- Also on this branch: the earlier fix to handle a `null` arrivals-and-departures upstream response gracefully (`parseStopDepartures` normalizes it to an empty result), which is what surfaces the empty state instead of an error.

## Test plan
- [x] `npm test` — 55/55 pass, including a new focused `board.test.js` pinning the `emptyMode` connecting/stale/empty branching (incl. the 90s staleness threshold)
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run lint` — clean
- [x] Browser-verified all three empty states **and** the populated board (no regression from the `visible.length === 0` branching) via Playwright with mocked OBA responses

## Review notes (non-blocking)
- The pulsing-dot chip and the ghost-row grid each duplicate a small amount of structure already present in `live-dot.svelte` / `board.svelte`'s filler rows. Extraction was deferred: `live-dot` bakes in fixed colors + SCHED/LIVE text, and the board's filler rows are interleaved in the real-rows grid rather than a standalone layer, so a shared primitive wouldn't cleanly serve both. Stable design tokens, low drift risk — flagging in case a reviewer prefers the extraction now.
- Empty-state copy is hardcoded English, matching the rest of the board family (DEPARTURES/ROUTE/WAYSTATION), which does not use Paraglide i18n. Worth revisiting if the board is localized later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added animated visual states for empty departure boards with contextual status messages (connecting, no departures, no live data)
  * Animations respect system motion preferences for accessibility

* **Bug Fixes**
  * Improved handling of missing or stale data responses

* **Tests**
  * Added test coverage for empty state scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->