### PR TITLE
Replace kiosk route body-class hack with +layout.svelte

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -33,19 +33,6 @@ body::before {
    Light mode reads cleanly on e-ink; Dark mode glows like a Solari board.
    ========================================================= */
 
-body.board-body {
-	margin: 0;
-	padding: 0;
-	background: #000;
-	overflow: hidden;
-	width: 100vw;
-	height: 100vh;
-	font-family: 'IBM Plex Sans', system-ui, sans-serif;
-}
-body.board-body::before {
-	display: none;
-}
-
 .board-stage-wrap {
 	position: fixed;
 	inset: 0;

--- a/src/routes/stops/[stopID]/+layout.svelte
+++ b/src/routes/stops/[stopID]/+layout.svelte
@@ -1,0 +1,19 @@
+<script>
+	let { children } = $props();
+</script>
+
+<div class="board-body">
+	{@render children()}
+</div>
+
+<style>
+	.board-body {
+		margin: 0;
+		padding: 0;
+		background: #000;
+		overflow: hidden;
+		width: 100vw;
+		height: 100vh;
+		font-family: 'IBM Plex Sans', system-ui, sans-serif;
+	}
+</style>

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -98,8 +98,6 @@
 	}
 
 	onMount(async () => {
-		document.body.classList.add('board-body');
-
 		try {
 			const res = await fetch('/api/config');
 			if (!res.ok) throw new Error(`/api/config returned ${res.status}`);
@@ -127,7 +125,6 @@
 	onDestroy(() => {
 		cancelled = true;
 		if (browser) {
-			document.body.classList.remove('board-body');
 			window.removeEventListener('resize', fitStage);
 		}
 		clearInterval(clockTimer);


### PR DESCRIPTION
Implements #78 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stop pages now use a dedicated full-screen layout with a consistent black background and improved viewport handling.
  * Nested stop content is now rendered within the page layout itself for a more stable presentation.

* **Bug Fixes**
  * Removed a page-level body styling approach to prevent layout conflicts and improve consistency across stop views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->