### PR TITLE
Clean up kiosk layout styling

### DIFF
--- a/src/routes/stops/[stopID]/+layout.svelte
+++ b/src/routes/stops/[stopID]/+layout.svelte
@@ -10,10 +10,11 @@
 	.board-body {
 		margin: 0;
 		padding: 0;
-		background: #000;
 		overflow: hidden;
-		width: 100vw;
-		height: 100vh;
 		font-family: 'IBM Plex Sans', system-ui, sans-serif;
+	}
+
+	:global(body)::before {
+		display: none;
 	}
 </style>


### PR DESCRIPTION
Closes #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated stop page layout styling to improve page rendering and prevent unwanted overflow.
  * Hid an on-page decorative/overlay element that was appearing behind the content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->