### PR TITLE
Fix: first-load error state for failed fetches

### DIFF
--- a/src/components/board/board.svelte
+++ b/src/components/board/board.svelte
@@ -20,6 +20,7 @@
 		now,
 		lastUpdatedAt = null,
 		isStale = false,
+		fetchFailed = false,
 		showStopName = false,
 		rowCount = 5,
 		showFooter = true,
@@ -34,7 +35,9 @@
 	const ageMs = $derived(updatedDate ? now.getTime() - updatedDate.getTime() : null);
 	const stale = $derived(isStale || (ageMs != null && ageMs > STALE_THRESHOLD_MS));
 	const showLive = $derived(liveCount > 0 && !stale);
-	const emptyMode = $derived(!updatedDate ? 'connecting' : stale ? 'stale' : 'empty');
+	const emptyMode = $derived(
+		!updatedDate && fetchFailed ? 'error' : !updatedDate ? 'connecting' : stale ? 'stale' : 'empty'
+	);
 </script>
 
 <div

--- a/src/components/board/board.svelte
+++ b/src/components/board/board.svelte
@@ -35,9 +35,10 @@
 	const ageMs = $derived(updatedDate ? now.getTime() - updatedDate.getTime() : null);
 	const stale = $derived(isStale || (ageMs != null && ageMs > STALE_THRESHOLD_MS));
 	const showLive = $derived(liveCount > 0 && !stale);
-	const emptyMode = $derived(
-		!updatedDate && fetchFailed ? 'error' : !updatedDate ? 'connecting' : stale ? 'stale' : 'empty'
-	);
+	const emptyMode = $derived.by(() => {
+		if (updatedDate) return stale ? 'stale' : 'empty';
+		return fetchFailed ? 'error' : 'connecting';
+	});
 </script>
 
 <div

--- a/src/components/board/board.test.js
+++ b/src/components/board/board.test.js
@@ -1,14 +1,13 @@
 // @vitest-environment jsdom
-
 import { render, cleanup } from '@testing-library/svelte';
 import { describe, test, expect, afterEach } from 'vitest';
 import Board from './board.svelte';
 
 // When a stop has no departures, the board renders the EmptyBoard whose headline
-// is driven by `emptyMode = !updatedDate ? 'connecting' : stale ? 'stale' : 'empty'`.
+// is driven by `emptyMode = !updatedDate && fetchFailed ? 'error' : !updatedDate ? 'connecting' : stale ? 'stale' : 'empty'`.
 // These tests pin that branching — the ternary ordering is easy to invert, and a
 // regression would silently show a rider the wrong state (e.g. "CONNECTING" forever
-// when the live feed is actually stale).
+// when the live feed is actually stale or down).
 describe('Board empty state', () => {
 	afterEach(() => {
 		cleanup();
@@ -23,6 +22,11 @@ describe('Board empty state', () => {
 	test('shows CONNECTING before the first fetch resolves', () => {
 		const { container } = renderEmpty({ lastUpdatedAt: null });
 		expect(container.innerHTML).toContain('CONNECTING');
+	});
+
+	test('shows NO DATA when all fetches fail on first load', () => {
+		const { container } = renderEmpty({ lastUpdatedAt: null, fetchFailed: true });
+		expect(container.innerHTML).toContain('NO DATA');
 	});
 
 	test('shows NO DEPARTURES once loaded with no service', () => {

--- a/src/components/board/board.test.js
+++ b/src/components/board/board.test.js
@@ -4,10 +4,11 @@ import { describe, test, expect, afterEach } from 'vitest';
 import Board from './board.svelte';
 
 // When a stop has no departures, the board renders the EmptyBoard whose headline
-// is driven by `emptyMode = !updatedDate && fetchFailed ? 'error' : !updatedDate ? 'connecting' : stale ? 'stale' : 'empty'`.
-// These tests pin that branching — the ternary ordering is easy to invert, and a
-// regression would silently show a rider the wrong state (e.g. "CONNECTING" forever
-// when the live feed is actually stale or down).
+// is driven by emptyMode (see board.svelte). The two axes are independent:
+//   has data?  yes: stale / empty    no: error / connecting
+// These tests pin every branch. The ordering is easy to invert and a regression
+// would silently show a rider the wrong state (e.g. "NO DATA" instead of "NO LIVE DATA"
+// when data exists but the feed has gone stale).
 describe('Board empty state', () => {
 	afterEach(() => {
 		cleanup();
@@ -24,11 +25,6 @@ describe('Board empty state', () => {
 		expect(container.innerHTML).toContain('CONNECTING');
 	});
 
-	test('shows NO DATA when all fetches fail on first load', () => {
-		const { container } = renderEmpty({ lastUpdatedAt: null, fetchFailed: true });
-		expect(container.innerHTML).toContain('NO DATA');
-	});
-
 	test('shows NO DEPARTURES once loaded with no service', () => {
 		const { container } = renderEmpty({ lastUpdatedAt: now.getTime(), isStale: false });
 		expect(container.innerHTML).toContain('NO DEPARTURES');
@@ -42,5 +38,15 @@ describe('Board empty state', () => {
 	test('shows NO LIVE DATA when data ages past the 90s staleness threshold', () => {
 		const { container } = renderEmpty({ lastUpdatedAt: now.getTime() - 91_000, isStale: false });
 		expect(container.innerHTML).toContain('NO LIVE DATA');
+	});
+
+	test('shows NO DATA when all fetches fail on first load', () => {
+		const { container } = renderEmpty({ lastUpdatedAt: null, fetchFailed: true });
+		expect(container.innerHTML).toContain('NO DATA');
+	});
+
+	test('does not show NO DATA when a fetch fails but data already exists', () => {
+		const { container } = renderEmpty({ lastUpdatedAt: now.getTime(), fetchFailed: true });
+		expect(container.innerHTML).not.toContain('NO DATA');
 	});
 });

--- a/src/components/board/empty-board.svelte
+++ b/src/components/board/empty-board.svelte
@@ -24,6 +24,13 @@
 			sub: 'Real-time feed unavailable — retrying',
 			chip: 'ATTEMPTING TO RECONNECT',
 			accent: 'var(--late)'
+		},
+		error: {
+			kicker: 'SIGNAL LOST',
+			head: 'NO DATA',
+			sub: 'Real-time data unavailable — check network',
+			chip: 'RETRYING',
+			accent: 'var(--late)'
 		}
 	};
 

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -25,6 +25,7 @@
 	let stopName = $state('');
 	let lastUpdatedAt = $state(null);
 	let isStale = $state(false);
+	let fetchFailed = $state(false);
 
 	const activeAlert = $derived(
 		situations.length > 0 ? situations[alertIndex % situations.length] : null
@@ -56,12 +57,17 @@
 			const ids = data.stopIDs;
 			const settled = await Promise.allSettled(ids.map(fetchStop));
 			const fulfilled = [];
+
 			settled.forEach((r, i) => {
 				if (r.status === 'fulfilled') fulfilled.push(r.value);
 				else console.error(`Board fetch failed for stop ${ids[i]}:`, r.reason);
 			});
 
-			if (fulfilled.length === 0) return;
+			if (fulfilled.length === 0) {
+				if (lastUpdatedAt === null) fetchFailed = true;
+
+				return;
+			}
 
 			const fetchNow = new Date();
 			const all = fulfilled.flatMap((r) => r.departures);
@@ -77,6 +83,7 @@
 			stopId = primary.stopId.split('_')[1] ?? primary.stopId;
 			stopName = primary.stopName;
 			lastUpdatedAt = fetchNow.getTime();
+			fetchFailed = false;
 		} finally {
 			fetchInFlight = false;
 		}
@@ -145,6 +152,7 @@
 			{now}
 			{lastUpdatedAt}
 			{isStale}
+			{fetchFailed}
 			{showStopName}
 			rowCount={Math.min(maxDepartures, 5)}
 		/>


### PR DESCRIPTION
Fixes #76 

- Board now shows "NO DATA — Real-time data unavailable" instead of spinning on "CONNECTING" indefinitely when every stop request fails
- Board recovers automatically once any request succeeds
- `fetchFailed` prop added to `Board` to carry the failure signal from page to component
- `'error'` copy added to `empty-board.svelte` using the same red accent as the stale state
- Test added for the new NO DATA state; `emptyMode` comment updated to reflect the new branch

# Results:
<img width="1920" height="946" alt="image" src="https://github.com/user-attachments/assets/2d6df61c-1ce2-4d9c-88ce-eab0a697dfcb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an error-style “NO DATA / SIGNAL LOST” empty view for boards when the initial fetch fails.

* **Bug Fixes**
  * Improved board empty-state logic to distinguish connecting, stale, empty, and failed-load scenarios.
  * Ensured the “NO DATA” message shows correctly when the first load returns no results.

* **Tests**
  * Added coverage for the initial-load failure case to confirm the correct error empty view is rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->