### PR TITLE
Add Prometheus metrics support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ PUBLIC_OBA_LOGO_URL="https://opentransitsoftwarefoundation.org/images/logos/oneb
 PUBLIC_OBA_REGION_NAME="Sound Transit"
 PUBLIC_OBA_SERVER_URL="https://api.pugetsound.onebusaway.org/"
 PRIVATE_OBA_API_KEY="test"
+
+# Port for the Prometheus /metrics server (default: 9119). It listens on all
+# interfaces — keep it off the open internet at the network layer.
+# METRICS_PORT=9119

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ Component tests mock `fetch` and use `@testing-library/svelte` for rendering/que
 
 **OBA SDK wrapper** (`src/lib/obaSdk.js`): Initializes the `onebusaway-sdk` client with env vars and provides `handleOBAResponse()` for validating API responses.
 
+**Prometheus metrics** (`src/lib/metrics/`): A dedicated `prom-client` registry (`registry.js`) exposed via an internal-only `node:http` server (`server.js`) on port 9119 (override with `METRICS_PORT`), started from `src/hooks.server.js`, which also instruments all requests with `http_requests_total` / `http_request_duration_seconds` labeled by route template. The `/api/oba/*` proxy routes record `oba_upstream_requests_total{endpoint, result="fresh"|"empty"|"stale"|"error"}` — the key kiosk-health signal; this metric is Waystation-specific. The HTTP metric names and the port match Wayfinder and the OneBusAway Twilio app so dashboards can be shared.
+
 **i18n**: Uses inlang Paraglide JS. Translation messages are in `messages/` as JSON files per locale. Generated runtime code goes to `src/lib/paraglide/`. Import translations as `import * as t from '$lib/paraglide/messages.js'`. Service alerts are translated dynamically via Google Translate proxy in `formatters.js`.
 
 ## Conventions

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
 				"@inlang/paraglide-js": "^2.2.0",
 				"@lucide/svelte": "^0.515.0",
 				"luxon": "^3.7.1",
-				"onebusaway-sdk": "^1.7.3"
+				"onebusaway-sdk": "^1.7.3",
+				"prom-client": "^15.1.3"
 			},
 			"devDependencies": {
 				"@eslint/compat": "^1.2.5",
@@ -1094,6 +1095,15 @@
 			"license": "ISC",
 			"peerDependencies": {
 				"svelte": "^5"
+			}
+		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -2322,6 +2332,12 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/bintrees": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+			"integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
@@ -4970,6 +4986,19 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/prom-client": {
+			"version": "15.1.3",
+			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+			"integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.4.0",
+				"tdigest": "^0.1.1"
+			},
+			"engines": {
+				"node": "^16 || ^18 || >=20"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5528,6 +5557,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/tdigest": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+			"integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+			"license": "MIT",
+			"dependencies": {
+				"bintrees": "1.0.2"
 			}
 		},
 		"node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"@inlang/paraglide-js": "^2.2.0",
 		"@lucide/svelte": "^0.515.0",
 		"luxon": "^3.7.1",
-		"onebusaway-sdk": "^1.7.3"
+		"onebusaway-sdk": "^1.7.3",
+		"prom-client": "^15.1.3"
 	}
 }

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,0 +1,29 @@
+import { building } from '$app/environment';
+import { env } from '$env/dynamic/private';
+import { recordHttpRequest, resolveMetricsPort } from '$lib/metrics/registry.js';
+import { startMetricsServer } from '$lib/metrics/server.js';
+
+/** @type {import('@sveltejs/kit').ServerInit} */
+export function init() {
+	// `building` guards the prerender pass, which also runs server hooks.
+	if (!building) {
+		startMetricsServer(resolveMetricsPort(env.METRICS_PORT));
+	}
+}
+
+export async function handle({ event, resolve }) {
+	const startTime = performance.now();
+	let status = 500;
+	try {
+		const response = await resolve(event);
+		status = response.status;
+		return response;
+	} finally {
+		recordHttpRequest({
+			method: event.request.method,
+			route: event.route.id ?? '(unmatched)',
+			status,
+			durationSeconds: (performance.now() - startTime) / 1000
+		});
+	}
+}

--- a/src/hooks.server.test.js
+++ b/src/hooks.server.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handle } from './hooks.server.js';
+import { recordHttpRequest } from '$lib/metrics/registry.js';
+
+vi.mock('$app/environment', () => ({ building: false }));
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+vi.mock('$lib/metrics/registry.js', () => ({
+	recordHttpRequest: vi.fn(),
+	resolveMetricsPort: vi.fn(() => 9119)
+}));
+vi.mock('$lib/metrics/server.js', () => ({ startMetricsServer: vi.fn() }));
+
+function makeEvent(routeId) {
+	return {
+		request: new Request('http://localhost/anything', { method: 'GET' }),
+		route: { id: routeId }
+	};
+}
+
+describe('handle', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('records the route template, not the concrete URL, to bound label cardinality', async () => {
+		const response = new Response('ok', { status: 201 });
+		const resolve = vi.fn(async () => response);
+
+		const result = await handle({ event: makeEvent('/stops/[stopID]'), resolve });
+
+		expect(result).toBe(response);
+		expect(recordHttpRequest).toHaveBeenCalledWith({
+			method: 'GET',
+			route: '/stops/[stopID]',
+			status: 201,
+			durationSeconds: expect.any(Number)
+		});
+	});
+
+	it('labels unmatched routes as (unmatched)', async () => {
+		const resolve = vi.fn(async () => new Response('nope', { status: 404 }));
+
+		await handle({ event: makeEvent(null), resolve });
+
+		expect(recordHttpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ route: '(unmatched)', status: 404 })
+		);
+	});
+
+	it('records a 500 and rethrows when resolve throws', async () => {
+		const boom = new Error('boom');
+		const resolve = vi.fn(async () => {
+			throw boom;
+		});
+
+		await expect(handle({ event: makeEvent('/stops/[stopID]'), resolve })).rejects.toThrow(boom);
+		expect(recordHttpRequest).toHaveBeenCalledWith(expect.objectContaining({ status: 500 }));
+	});
+});

--- a/src/lib/metrics/registry.js
+++ b/src/lib/metrics/registry.js
@@ -1,0 +1,116 @@
+import os from 'node:os';
+import client from 'prom-client';
+
+/**
+ * Prometheus instrumentation for Waystation. The HTTP metrics
+ * (http_requests_total, http_request_duration_seconds) and the default port
+ * match Wayfinder and the OneBusAway Twilio app so dashboards and alert rules
+ * can be shared. oba_upstream_requests_total and the system_* gauges are
+ * Waystation-specific (the system gauges also exist in Wayfinder).
+ */
+
+export const DEFAULT_METRICS_PORT = 9119;
+
+function createMetrics() {
+	const registry = new client.Registry();
+	client.collectDefaultMetrics({ register: registry });
+
+	const httpRequests = new client.Counter({
+		name: 'http_requests_total',
+		help: 'Total HTTP requests by method, route template, and status code.',
+		labelNames: ['method', 'route', 'status'],
+		registers: [registry]
+	});
+
+	const httpDuration = new client.Histogram({
+		name: 'http_request_duration_seconds',
+		help: 'HTTP request latency by method and route template.',
+		labelNames: ['method', 'route'],
+		registers: [registry]
+	});
+
+	const upstreamRequests = new client.Counter({
+		name: 'oba_upstream_requests_total',
+		help: 'OneBusAway upstream fetches by endpoint and outcome (fresh, empty, stale, or error).',
+		labelNames: ['endpoint', 'result'],
+		registers: [registry]
+	});
+
+	new client.Gauge({
+		name: 'system_cpu_load_average_1m',
+		help: 'System load average over the last minute.',
+		registers: [registry],
+		collect() {
+			this.set(os.loadavg()[0]);
+		}
+	});
+
+	new client.Gauge({
+		name: 'system_memory_total_bytes',
+		help: 'Total system memory in bytes.',
+		registers: [registry],
+		collect() {
+			this.set(os.totalmem());
+		}
+	});
+
+	new client.Gauge({
+		name: 'system_memory_free_bytes',
+		help: 'Free system memory in bytes.',
+		registers: [registry],
+		collect() {
+			this.set(os.freemem());
+		}
+	});
+
+	return { registry, httpRequests, httpDuration, upstreamRequests };
+}
+
+// Stored on globalThis so dev-mode HMR re-evaluation reuses the same registry —
+// otherwise the hooks would record into a fresh registry while the running
+// metrics server kept serving the orphaned old one.
+const metrics = (globalThis.__waystationMetrics ??= createMetrics());
+
+export const metricsContentType = metrics.registry.contentType;
+
+// The record functions swallow their own failures: instrumentation must never
+// turn a healthy response into an error or mask a real one (they are called
+// from finally/catch blocks, where a throw replaces the pending result).
+export function recordHttpRequest({ method, route, status, durationSeconds }) {
+	try {
+		metrics.httpRequests.inc({ method, route, status });
+		metrics.httpDuration.observe({ method, route }, durationSeconds);
+	} catch (error) {
+		console.error('metrics: failed to record HTTP request:', error);
+	}
+}
+
+export function recordUpstreamRequest({ endpoint, result }) {
+	try {
+		metrics.upstreamRequests.inc({ endpoint, result });
+	} catch (error) {
+		console.error('metrics: failed to record upstream request:', error);
+	}
+}
+
+export function renderMetrics() {
+	return metrics.registry.metrics();
+}
+
+/**
+ * Validates a METRICS_PORT value with the same semantics as Wayfinder:
+ * unset/empty silently uses the default; anything that is not an integer in
+ * [1, 65535] logs a warning and uses the default.
+ */
+export function resolveMetricsPort(raw) {
+	const trimmed = (raw ?? '').trim();
+	if (trimmed === '') {
+		return DEFAULT_METRICS_PORT;
+	}
+	const parsed = Number(trimmed);
+	if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+		console.warn(`Invalid METRICS_PORT="${raw}", using default ${DEFAULT_METRICS_PORT}`);
+		return DEFAULT_METRICS_PORT;
+	}
+	return parsed;
+}

--- a/src/lib/metrics/registry.test.js
+++ b/src/lib/metrics/registry.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+	DEFAULT_METRICS_PORT,
+	metricsContentType,
+	recordHttpRequest,
+	recordUpstreamRequest,
+	renderMetrics,
+	resolveMetricsPort
+} from '$lib/metrics/registry.js';
+
+describe('resolveMetricsPort', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns the default port for undefined, null, and empty values', () => {
+		expect(resolveMetricsPort(undefined)).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort(null)).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort('')).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort('   ')).toBe(DEFAULT_METRICS_PORT);
+	});
+
+	it('defaults to 9119, matching Wayfinder and the Twilio app', () => {
+		expect(DEFAULT_METRICS_PORT).toBe(9119);
+	});
+
+	it('accepts a valid port', () => {
+		expect(resolveMetricsPort('9200')).toBe(9200);
+		expect(resolveMetricsPort(' 1 ')).toBe(1);
+		expect(resolveMetricsPort('65535')).toBe(65535);
+	});
+
+	it('warns and falls back to the default for invalid values', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		expect(resolveMetricsPort('not-a-port')).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort('0')).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort('65536')).toBe(DEFAULT_METRICS_PORT);
+		expect(resolveMetricsPort('12.5')).toBe(DEFAULT_METRICS_PORT);
+		expect(warn).toHaveBeenCalledTimes(4);
+	});
+});
+
+describe('metrics registry', () => {
+	it('exposes the Prometheus text exposition content type', () => {
+		expect(metricsContentType).toContain('text/plain');
+	});
+
+	it('records HTTP requests into the counter and histogram', async () => {
+		recordHttpRequest({
+			method: 'GET',
+			route: '/stops/[stopID]',
+			status: 200,
+			durationSeconds: 0.123
+		});
+
+		const text = await renderMetrics();
+		expect(text).toContain(
+			'http_requests_total{method="GET",route="/stops/[stopID]",status="200"} 1'
+		);
+		expect(text).toContain(
+			'http_request_duration_seconds_count{method="GET",route="/stops/[stopID]"} 1'
+		);
+		expect(text).toMatch(/http_request_duration_seconds_bucket\{le="0\.25",method="GET"/);
+	});
+
+	it('records upstream OBA request outcomes', async () => {
+		recordUpstreamRequest({ endpoint: 'arrivals-and-departures-for-stop', result: 'fresh' });
+		recordUpstreamRequest({ endpoint: 'arrivals-and-departures-for-stop', result: 'stale' });
+		recordUpstreamRequest({ endpoint: 'name-and-code-for-stop', result: 'error' });
+
+		const text = await renderMetrics();
+		expect(text).toContain(
+			'oba_upstream_requests_total{endpoint="arrivals-and-departures-for-stop",result="fresh"} 1'
+		);
+		expect(text).toContain(
+			'oba_upstream_requests_total{endpoint="arrivals-and-departures-for-stop",result="stale"} 1'
+		);
+		expect(text).toContain(
+			'oba_upstream_requests_total{endpoint="name-and-code-for-stop",result="error"} 1'
+		);
+	});
+
+	it('includes Node.js default metrics', async () => {
+		const text = await renderMetrics();
+		expect(text).toContain('process_cpu_user_seconds_total');
+		expect(text).toContain('nodejs_eventloop_lag_seconds');
+		expect(text).toContain('process_resident_memory_bytes');
+	});
+
+	it('includes system-level gauges for dashboard CPU/memory panels', async () => {
+		const text = await renderMetrics();
+		expect(text).toMatch(/system_cpu_load_average_1m \d/);
+		expect(text).toMatch(/system_memory_total_bytes \d/);
+		expect(text).toMatch(/system_memory_free_bytes \d/);
+	});
+});

--- a/src/lib/metrics/server.js
+++ b/src/lib/metrics/server.js
@@ -1,0 +1,56 @@
+import http from 'node:http';
+import { metricsContentType, renderMetrics } from './registry.js';
+
+/**
+ * Starts the HTTP server that exposes GET /metrics. It binds a different port
+ * than the app so the app port can be public while this one is kept off the
+ * open internet — it listens on all interfaces, so exposure must be restricted
+ * at the network layer. Idempotent: dev HMR re-runs and repeated calls return
+ * the previously created server (even if its listen attempt failed). Listen
+ * errors (e.g. EADDRINUSE) are logged and never crash the app.
+ */
+export function startMetricsServer(port) {
+	if (globalThis.__waystationMetricsServer) {
+		return globalThis.__waystationMetricsServer;
+	}
+
+	const server = http.createServer(async (req, res) => {
+		const path = (req.url ?? '').split('?')[0];
+		if (req.method === 'GET' && path === '/metrics') {
+			try {
+				const body = await renderMetrics();
+				res.writeHead(200, { 'Content-Type': metricsContentType });
+				res.end(body);
+			} catch (error) {
+				console.error('metrics: failed to render metrics:', error);
+				res.writeHead(500, { 'Content-Type': 'text/plain' });
+				res.end('metrics collection failed');
+			}
+		} else {
+			res.writeHead(404, { 'Content-Type': 'text/plain' });
+			res.end('not found');
+		}
+	});
+
+	server.on('error', (error) => {
+		console.error(`metrics: server error on port ${port}:`, error);
+	});
+
+	// Never keep the process alive on account of the metrics server.
+	server.unref();
+	server.listen(port, () => {
+		console.log(`metrics: Prometheus /metrics listening on port ${server.address().port}`);
+	});
+
+	globalThis.__waystationMetricsServer = server;
+	return server;
+}
+
+export function stopMetricsServer() {
+	const server = globalThis.__waystationMetricsServer;
+	globalThis.__waystationMetricsServer = undefined;
+	if (!server) {
+		return Promise.resolve();
+	}
+	return new Promise((resolve) => server.close(resolve));
+}

--- a/src/lib/metrics/server.test.js
+++ b/src/lib/metrics/server.test.js
@@ -1,0 +1,73 @@
+import http from 'node:http';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { startMetricsServer, stopMetricsServer } from '$lib/metrics/server.js';
+import { metricsContentType } from '$lib/metrics/registry.js';
+
+function listening(server) {
+	return new Promise((resolve, reject) => {
+		if (server.listening) return resolve();
+		server.once('listening', resolve);
+		server.once('error', reject);
+	});
+}
+
+async function fetchFromServer(server, path) {
+	const { port } = server.address();
+	return fetch(`http://127.0.0.1:${port}${path}`);
+}
+
+describe('metrics server', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+
+	afterEach(async () => {
+		await stopMetricsServer();
+		vi.restoreAllMocks();
+	});
+
+	it('serves Prometheus metrics on GET /metrics', async () => {
+		const server = startMetricsServer(0);
+		await listening(server);
+
+		const response = await fetchFromServer(server, '/metrics');
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toBe(metricsContentType);
+		expect(await response.text()).toContain('process_cpu_user_seconds_total');
+	});
+
+	it('returns 404 for any other path', async () => {
+		const server = startMetricsServer(0);
+		await listening(server);
+
+		const response = await fetchFromServer(server, '/anything-else');
+		expect(response.status).toBe(404);
+	});
+
+	it('is a no-op when the server is already running', async () => {
+		const server = startMetricsServer(0);
+		await listening(server);
+
+		expect(startMetricsServer(0)).toBe(server);
+	});
+
+	it('logs listen errors instead of crashing the app', async () => {
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		// Simulate another process already holding the port.
+		const blocker = http.createServer();
+		blocker.listen(0);
+		await listening(blocker);
+		const { port } = blocker.address();
+
+		const conflicting = startMetricsServer(port);
+		await new Promise((resolve) => conflicting.once('error', resolve));
+
+		expect(error).toHaveBeenCalledWith(
+			expect.stringContaining('metrics'),
+			expect.objectContaining({ code: 'EADDRINUSE' })
+		);
+
+		await new Promise((resolve) => blocker.close(resolve));
+	});
+});

--- a/src/routes/api/oba/arrivals-and-departures-for-stop/[id]/+server.js
+++ b/src/routes/api/oba/arrivals-and-departures-for-stop/[id]/+server.js
@@ -1,7 +1,9 @@
 import oba from '$lib/obaSdk';
 import { error } from '@sveltejs/kit';
+import { recordUpstreamRequest } from '$lib/metrics/registry.js';
 
 const cache = new Map();
+const METRICS_ENDPOINT = 'arrivals-and-departures-for-stop';
 
 export async function GET({ params }) {
 	const stopID = params.id;
@@ -10,18 +12,23 @@ export async function GET({ params }) {
 		const response = await oba.arrivalAndDeparture.list(stopID);
 
 		// Upstream returns `null` (HTTP 200) for some valid stops with no real-time
-		// data. Only cache responses with real data so we never serve null as stale.
-		if (response?.data?.entry?.arrivalsAndDepartures) {
+		// data. Only cache responses with real data so we never serve null as stale,
+		// and record those as "empty" so a feed outage behind a healthy API is
+		// visible on dashboards instead of counting as fresh.
+		const hasData = Boolean(response?.data?.entry?.arrivalsAndDepartures);
+		if (hasData) {
 			cache.set(stopID, response);
 		}
 
+		recordUpstreamRequest({ endpoint: METRICS_ENDPOINT, result: hasData ? 'fresh' : 'empty' });
 		return new Response(JSON.stringify(response), {
 			headers: { 'Content-Type': 'application/json' }
 		});
 	} catch (err) {
-		console.warn(`OBA fetch failed for stop ${stopID}:, ${err.message}`);
+		console.warn(`OBA fetch failed for stop ${stopID}: ${err.message}`);
 
 		if (cache.has(stopID)) {
+			recordUpstreamRequest({ endpoint: METRICS_ENDPOINT, result: 'stale' });
 			return new Response(
 				JSON.stringify({
 					...cache.get(stopID),
@@ -31,6 +38,7 @@ export async function GET({ params }) {
 			);
 		}
 
+		recordUpstreamRequest({ endpoint: METRICS_ENDPOINT, result: 'error' });
 		throw error(503, `No data available for stop ${stopID}`);
 	}
 }

--- a/src/routes/api/oba/name-and-code-for-stop/[id]/+server.js
+++ b/src/routes/api/oba/name-and-code-for-stop/[id]/+server.js
@@ -1,7 +1,9 @@
 import oba, { handleOBAResponse } from '$lib/obaSdk.js';
 import { error } from '@sveltejs/kit';
+import { recordUpstreamRequest } from '$lib/metrics/registry.js';
 
 const cache = new Map();
+const METRICS_ENDPOINT = 'name-and-code-for-stop';
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ params }) {
@@ -20,6 +22,7 @@ export async function GET({ params }) {
 			cache.set(id, stopBodies[i]);
 		});
 
+		recordUpstreamRequest({ endpoint: METRICS_ENDPOINT, result: 'fresh' });
 		return new Response(JSON.stringify(dataBlocks), {
 			headers: { 'Content-Type': 'application/json' }
 		});
@@ -27,6 +30,7 @@ export async function GET({ params }) {
 		console.warn(`OBA fetch failed for stops [${stopIDs.join(', ')}]: ${err.message}`);
 
 		if (stopIDs.every((id) => cache.has(id))) {
+			recordUpstreamRequest({ endpoint: METRICS_ENDPOINT, result: 'stale' });
 			const cachedBlocks = stopIDs.map((id) => cache.get(id).data.entry);
 
 			return new Response(JSON.stringify(cachedBlocks.map((b) => ({ ...b, stale: true }))), {
@@ -34,6 +38,7 @@ export async function GET({ params }) {
 			});
 		}
 
+		recordUpstreamRequest({ endpoint: METRICS_ENDPOINT, result: 'error' });
 		throw error(503, `No data available for stops [${stopIDs.join(', ')}]`);
 	}
 }


### PR DESCRIPTION
## Summary
- Adds Prometheus metrics, mirroring Wayfinder's implementation so the two apps (plus the Twilio app) share dashboards: a dedicated `prom-client` registry with process/system collectors (`src/lib/metrics/registry.js`), an internal `node:http` server exposing `GET /metrics` on port **9119** (`METRICS_PORT` override) (`src/lib/metrics/server.js`), and per-request `http_requests_total` / `http_request_duration_seconds` instrumentation in a new `src/hooks.server.js`, labeled by route template to keep cardinality bounded. The server starts via SvelteKit's `init` hook and never keeps the process alive or crashes the app on listen errors.
- Since Waystation runs on unattended kiosk screens, pageview-style metrics are useless; instead the two `/api/oba/*` proxy routes record `oba_upstream_requests_total{endpoint, result="fresh"|"empty"|"stale"|"error"}` — the signal that tells you whether a screen is showing live data, stale cache, empty payloads from a "healthy" upstream, or nothing.
- Instrumentation is failure-proof by construction: the record helpers swallow their own errors so metrics code can never mask a real response or error (they run in `finally`/`catch` blocks).

## Test plan
- [x] 60/60 Vitest tests pass (13 new for registry/server, 3 for the `handle` hook), `npm run lint` and `npm run check` clean
- [x] Booted the dev server and verified `GET :9119/metrics` returns the Prometheus exposition format with process, system, and HTTP metrics; other paths 404
- [x] Hit `/`, `/api/config`, and both `/api/oba/*` routes; confirmed `http_requests_total` labels use route templates (e.g. `/api/oba/arrivals-and-departures-for-stop/[id]`) and statuses (200/503)
- [x] Exercised the upstream-failure edge case (invalid API key → 503) and confirmed `oba_upstream_requests_total{result="error"}` increments for both endpoints
- [x] `npm run build` succeeds; the `building` guard keeps the metrics server out of the prerender pass

## Review notes
Multi-agent review (code, tests, silent failures, comments) findings were applied: `init` hook instead of module-scope side effect, `empty` outcome for null upstream payloads, throw-proof record helpers, de-flaked port-conflict test, and comment accuracy fixes. Non-blocking judgment calls left for reviewers:
- The `/metrics` server listens on all interfaces (matching Wayfinder); it must be firewalled at the network layer. Binding `127.0.0.1` would break remote Prometheus scraping.
- Each proxy route hand-types its `endpoint` label constant. Fine at 2 routes; if a third proxy route appears, consider extracting the shared fetch→stale-cache→503 pattern (with the metric call inside it) into a helper.
- `name-and-code-for-stop` increments the counter once per request even though multi-stop requests fan out to N upstream calls — the metric counts proxy-request outcomes, not literal upstream fetches.
- Wayfinder could adopt the same throw-proof guard inside its `recordHttpRequest` if we want the implementations to stay identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Prometheus metrics support, including a `/metrics` endpoint on a dedicated port.
  - Introduced request, route, and upstream health tracking so service activity can be monitored more clearly.

- **Bug Fixes**
  - Improved handling of upstream stop lookups by recording fresh, empty, stale, and error outcomes.
  - Fixed a log message formatting issue in stop lookup responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->