### PR TITLE
Surface partial-stop failures on multi-stop boards

### DIFF
--- a/src/components/board/board.svelte
+++ b/src/components/board/board.svelte
@@ -40,7 +40,7 @@
 		if (updatedDate) return stale ? 'stale' : 'empty';
 		return fetchFailed ? 'error' : 'connecting';
 	});
-	const showFailedBadge = $derived(failedStopIds.length > 0 && arrivals.length > 0);
+	const showFailedBadge = $derived(failedStopIds.length > 0);
 </script>
 
 <div
@@ -150,7 +150,7 @@
 				style:border="1px solid var(--late)"
 				style:border-left="4px solid var(--late)"
 				style:border-radius="2px"
-				style:background="rgba(255, 139, 106, 0.06)"
+				style:background="color-mix(in srgb, var(--late) 6%, transparent)"
 				style:font-size="20px"
 				style:letter-spacing="0.18em"
 				style:color="var(--late)"

--- a/src/components/board/board.svelte
+++ b/src/components/board/board.svelte
@@ -21,6 +21,7 @@
 		lastUpdatedAt = null,
 		isStale = false,
 		fetchFailed = false,
+		failedStopIds = [],
 		showStopName = false,
 		rowCount = 5,
 		showFooter = true,
@@ -39,6 +40,7 @@
 		if (updatedDate) return stale ? 'stale' : 'empty';
 		return fetchFailed ? 'error' : 'connecting';
 	});
+	const showFailedBadge = $derived(failedStopIds.length > 0 && arrivals.length > 0);
 </script>
 
 <div
@@ -134,6 +136,31 @@
 
 		{#if hasAlert}
 			<AlertBadge situation={alert} />
+		{/if}
+
+		{#if showFailedBadge}
+			<div
+				class="sc"
+				style:grid-column="1 / -1"
+				style:display="inline-flex"
+				style:align-items="center"
+				style:gap="12px"
+				style:margin-top="12px"
+				style:padding="10px 18px"
+				style:border="1px solid var(--late)"
+				style:border-left="4px solid var(--late)"
+				style:border-radius="2px"
+				style:background="rgba(255, 139, 106, 0.06)"
+				style:font-size="20px"
+				style:letter-spacing="0.18em"
+				style:color="var(--late)"
+				style:font-weight="700"
+			>
+				<span>
+					DATA UNAVAILABLE FOR STOP{failedStopIds.length > 1 ? 'S' : ''}
+					{failedStopIds.map((id) => '#' + (id.split('_')[1] ?? id)).join(', ')}
+				</span>
+			</div>
 		{/if}
 	</section>
 

--- a/src/components/board/board.test.js
+++ b/src/components/board/board.test.js
@@ -61,4 +61,14 @@ describe('Board empty state', () => {
 		});
 		expect(container.innerHTML).toContain('DATA UNAVAILABLE FOR STOP');
 	});
+
+	test('shows the failed-stop badge with no arrivals at all', () => {
+		const { container } = renderEmpty({
+			lastUpdatedAt: now.getTime(),
+			isStale: false,
+			failedStopIds: ['1_200']
+		});
+		expect(container.innerHTML).toContain('DATA UNAVAILABLE FOR STOP');
+		expect(container.innerHTML).toContain('#200');
+	});
 });

--- a/src/components/board/board.test.js
+++ b/src/components/board/board.test.js
@@ -49,4 +49,16 @@ describe('Board empty state', () => {
 		const { container } = renderEmpty({ lastUpdatedAt: now.getTime(), fetchFailed: true });
 		expect(container.innerHTML).not.toContain('NO DATA');
 	});
+
+	test('shows the failed-stop badge even when the surviving stop has arrivals', () => {
+		const { container } = render(Board, {
+			props: {
+				now,
+				lastUpdatedAt: now.getTime(),
+				arrivals: [{ tripId: 't1', route: '49', departureAt: now.getTime() + 60_000, min: 1 }],
+				failedStopIds: ['1_200']
+			}
+		});
+		expect(container.innerHTML).toContain('DATA UNAVAILABLE FOR STOP');
+	});
 });

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -26,6 +26,7 @@
 	let lastUpdatedAt = $state(null);
 	let isStale = $state(false);
 	let fetchFailed = $state(false);
+	let failedStopIds = $state([]);
 
 	const activeAlert = $derived(
 		situations.length > 0 ? situations[alertIndex % situations.length] : null
@@ -57,11 +58,16 @@
 			const ids = data.stopIDs;
 			const settled = await Promise.allSettled(ids.map(fetchStop));
 			const fulfilled = [];
+			const failed = [];
 
 			settled.forEach((r, i) => {
 				if (r.status === 'fulfilled') fulfilled.push(r.value);
-				else console.error(`Board fetch failed for stop ${ids[i]}:`, r.reason);
+				else {
+					console.error(`Board fetch failed for stop ${ids[i]}:`, r.reason);
+					failed.push(ids[i]);
+				}
 			});
+			failedStopIds = failed;
 
 			if (fulfilled.length === 0) {
 				if (lastUpdatedAt === null) fetchFailed = true;
@@ -153,6 +159,7 @@
 			{lastUpdatedAt}
 			{isStale}
 			{fetchFailed}
+			{failedStopIds}
 			{showStopName}
 			rowCount={Math.min(maxDepartures, 5)}
 		/>


### PR DESCRIPTION
Fixes #75 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a data-unavailable banner when departure information cannot be retrieved for one or more stops.
  * The banner lists affected stop identifiers and adjusts its wording for one or multiple stops.
  * Partial data-fetch failures are now surfaced directly on the departures board.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->