### PR TITLE
Eliminate departure row flicker on each refresh

### DIFF
--- a/src/components/board/board.svelte
+++ b/src/components/board/board.svelte
@@ -21,6 +21,7 @@
 		lastUpdatedAt = null,
 		isStale = false,
 		fetchFailed = false,
+		failedStopIds = [],
 		showStopName = false,
 		rowCount = 5,
 		showFooter = true,
@@ -39,6 +40,7 @@
 		if (updatedDate) return stale ? 'stale' : 'empty';
 		return fetchFailed ? 'error' : 'connecting';
 	});
+	const showFailedBadge = $derived(failedStopIds.length > 0 && arrivals.length > 0);
 </script>
 
 <div
@@ -134,6 +136,31 @@
 
 		{#if hasAlert}
 			<AlertBadge situation={alert} />
+		{/if}
+
+		{#if showFailedBadge}
+			<div
+				class="sc"
+				style:grid-column="1 / -1"
+				style:display="inline-flex"
+				style:align-items="center"
+				style:gap="12px"
+				style:margin-top="12px"
+				style:padding="10px 18px"
+				style:border="1px solid var(--late)"
+				style:border-left="4px solid var(--late)"
+				style:border-radius="2px"
+				style:background="rgba(255, 139, 106, 0.06)"
+				style:font-size="20px"
+				style:letter-spacing="0.18em"
+				style:color="var(--late)"
+				style:font-weight="700"
+			>
+				<span>
+					DATA UNAVAILABLE FOR STOP{failedStopIds.length > 1 ? 'S' : ''}
+					{failedStopIds.map((id) => '#' + (id.split('_')[1] ?? id)).join(', ')}
+				</span>
+			</div>
 		{/if}
 	</section>
 

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -402,6 +402,30 @@ export function parseStopDepartures(json, id) {
 }
 
 /**
+ * Merge an incoming arrivals list against the current one, preserving object
+ * references for rows that have not changed. Svelte's keyed {#each} skips DOM
+ * updates for rows whose object reference is unchanged, eliminating per-tick
+ * flicker even though the outer array is replaced on every fetch.
+ *
+ * @param {Array} prev - Current arrivals array held in $state
+ * @param {Array} next - Freshly formatted arrivals from the latest fetch
+ * @returns {Array} - next, with unchanged rows replaced by their prev reference
+ */
+export function diffArrivals(prev, next) {
+	const prevMap = new Map(prev.map((a) => [a.tripId, a]));
+	return next.map((n) => {
+		const p = prevMap.get(n.tripId);
+		if (!p) return n;
+		const unchanged =
+			p.min === n.min &&
+			p.status === n.status &&
+			p.delta === n.delta &&
+			p.departureAt === n.departureAt;
+		return unchanged ? p : n;
+	});
+}
+
+/**
  * Translates a given text into the specified target language by proxying
  * through Google’s unofficial translate endpoint.
  *

--- a/src/lib/formatters.test.js
+++ b/src/lib/formatters.test.js
@@ -6,6 +6,7 @@ import {
 	formatDateTime,
 	formatTime,
 	formatDate,
+	diffArrivals,
 	formatCurrentTime,
 	formatTimestamp,
 	formatArrivalStatus,
@@ -49,6 +50,29 @@ describe('formatters', () => {
 		test('formatTimestamp gives readable short format', () => {
 			const ts = new Date('2025-06-18T00:00:00').getTime();
 			expect(formatTimestamp(ts)).toMatch(/Wed, Jun 18, 2025/);
+		});
+	});
+
+	describe('diffArrivals', () => {
+		test('preserves object reference when row is unchanged', () => {
+			const prev = [{ tripId: 'A', min: 5, status: 'ONTIME', delta: 0, departureAt: 1000 }];
+			const next = [{ tripId: 'A', min: 5, status: 'ONTIME', delta: 0, departureAt: 1000 }];
+			const result = diffArrivals(prev, next);
+			expect(result[0]).toBe(prev[0]);
+		});
+
+		test('returns new object when row has changed', () => {
+			const prev = [{ tripId: 'A', min: 5, status: 'ONTIME', delta: 0, departureAt: 1000 }];
+			const next = [{ tripId: 'A', min: 4, status: 'ONTIME', delta: 0, departureAt: 1000 }];
+			const result = diffArrivals(prev, next);
+			expect(result[0]).toBe(next[0]);
+		});
+
+		test('returns new object for a row not in prev', () => {
+			const prev = [];
+			const next = [{ tripId: 'A', min: 5, status: 'ONTIME', delta: 0, departureAt: 1000 }];
+			const result = diffArrivals(prev, next);
+			expect(result[0]).toBe(next[0]);
 		});
 	});
 

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -5,6 +5,7 @@
 
 	import Board from '$components/board/board.svelte';
 	import {
+		diffArrivals,
 		formatBoardDeparture,
 		parseStopDepartures,
 		removeDuplicates,
@@ -81,7 +82,7 @@
 				.map((dep) => formatBoardDeparture(dep, fetchNow))
 				.filter((a) => a.min >= -2);
 
-			arrivals = mapped;
+			arrivals = diffArrivals(arrivals, mapped);
 			situations = fulfilled.flatMap((r) => r.situations).filter((s) => s?.summary?.value);
 			isStale = fulfilled.some((r) => r.stale);
 

--- a/src/routes/stops/[stopID]/+page.svelte
+++ b/src/routes/stops/[stopID]/+page.svelte
@@ -26,6 +26,7 @@
 	let lastUpdatedAt = $state(null);
 	let isStale = $state(false);
 	let fetchFailed = $state(false);
+	let failedStopIds = $state([]);
 
 	const activeAlert = $derived(
 		situations.length > 0 ? situations[alertIndex % situations.length] : null
@@ -57,11 +58,16 @@
 			const ids = data.stopIDs;
 			const settled = await Promise.allSettled(ids.map(fetchStop));
 			const fulfilled = [];
+			const failed = [];
 
 			settled.forEach((r, i) => {
 				if (r.status === 'fulfilled') fulfilled.push(r.value);
-				else console.error(`Board fetch failed for stop ${ids[i]}:`, r.reason);
+				else {
+					console.error(`Board fetch failed for stop ${ids[i]}:`, r.reason);
+					failed.push(ids[i]);
+				}
 			});
+			failedStopIds = failed;
 
 			if (fulfilled.length === 0) {
 				if (lastUpdatedAt === null) fetchFailed = true;
@@ -153,6 +159,7 @@
 			{lastUpdatedAt}
 			{isStale}
 			{fetchFailed}
+			{failedStopIds}
 			{showStopName}
 			rowCount={Math.min(maxDepartures, 5)}
 		/>


### PR DESCRIPTION
Implements #61 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible banner identifying stops whose arrival data is unavailable.
  * Failed stop IDs are now displayed when partial data retrieval issues occur.

* **Bug Fixes**
  * Preserved unchanged arrival rows during refreshes to reduce unnecessary visual updates.
  * Continued displaying available arrival information when some stops fail to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->